### PR TITLE
Restrict direct access to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,41 @@ Then open <http://localhost:21000>.
 | `TRUST_PROXY` | private addresses    | Which upstreams may set `X-Forwarded-*`. Accepts Express `trust proxy` values.                          |
 | `TZ`          | `UTC`               | Container timezone.                                                                                     |
 
-The published port is bound to `127.0.0.1`, so only a reverse proxy running on
-the same host can reach it — not the wider LAN. If the proxy later moves into a
-container of its own, drop the `ports` block and join both stacks on a shared
-external network instead; `compose.yaml` carries the exact steps.
+### Putting a reverse proxy in front
+
+The port is bound to `127.0.0.1`, so only the machine itself can reach the bar.
+A reverse proxy on the same machine is what makes it reachable from outside:
+
+```caddyfile
+bar.example.com {
+	reverse_proxy localhost:21000
+}
+```
+
+Caddy needs no extra settings — it handles both the live order updates and the
+image files as they are.
+
+If the proxy runs in its own container instead, share a network with it rather
+than publishing a port. Create the network once:
+
+```sh
+docker network create edge
+```
+
+Then remove the `ports` block from `compose.yaml` and add:
+
+```yaml
+services:
+  home-bar:
+    networks: [edge]
+
+networks:
+  edge:
+    external: true
+```
+
+The proxy joins the same network and points at `home-bar:3000`. The bar is then
+not reachable from outside Docker at all.
 
 The container reports health on `/api/health`, so `docker ps` and Dockge show a
 real status rather than just "running".

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ Then open <http://localhost:21000>.
 | `UPLOADS_DIR` | `/app/uploads`      | Uploaded drink images.                                                                                  |
 | `PUBLIC_URL`  | derived from request | Base URL baked into guest QR codes. Only needed when guests reach the bar on a different address.       |
 | `PUID`/`PGID` | unset (runs as root) | Run as an unprivileged user. Ownership of the data directories is adjusted on start.                    |
+| `TRUST_PROXY` | private addresses    | Which upstreams may set `X-Forwarded-*`. Accepts Express `trust proxy` values.                          |
 | `TZ`          | `UTC`               | Container timezone.                                                                                     |
+
+The published port is bound to `127.0.0.1`, so only a reverse proxy running on
+the same host can reach it — not the wider LAN. If the proxy later moves into a
+container of its own, drop the `ports` block and join both stacks on a shared
+external network instead; `compose.yaml` carries the exact steps.
 
 The container reports health on `/api/health`, so `docker ps` and Dockge show a
 real status rather than just "running".

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -45,3 +45,21 @@ export const PUBLIC_URL = (
   process.env.FRONTEND_URL ||
   ""
 ).replace(/\/+$/, "");
+
+// Which upstreams may set X-Forwarded-*. Those headers decide the scheme and
+// host in generated QR codes, so trusting them from anywhere lets a request
+// that bypasses the proxy point a QR code elsewhere.
+//
+// The default trusts only private and loopback addresses, which covers both
+// supported topologies — Caddy on the host reaching the container over the
+// Docker bridge, and Caddy in Docker on a shared network — while ignoring the
+// headers from any public source. Accepts Express's `trust proxy` values: a
+// boolean, a hop count, or a comma-separated list of addresses/subnets/presets.
+export const TRUST_PROXY = (() => {
+  const raw = process.env.TRUST_PROXY;
+  if (raw === undefined || raw === "") return "loopback, linklocal, uniquelocal";
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  return raw;
+})();

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -46,15 +46,9 @@ export const PUBLIC_URL = (
   ""
 ).replace(/\/+$/, "");
 
-// Which upstreams may set X-Forwarded-*. Those headers decide the scheme and
-// host in generated QR codes, so trusting them from anywhere lets a request
-// that bypasses the proxy point a QR code elsewhere.
-//
-// The default trusts only private and loopback addresses, which covers both
-// supported topologies — Caddy on the host reaching the container over the
-// Docker bridge, and Caddy in Docker on a shared network — while ignoring the
-// headers from any public source. Accepts Express's `trust proxy` values: a
-// boolean, a hop count, or a comma-separated list of addresses/subnets/presets.
+// Which reverse proxies are allowed to tell us the address guests used. By
+// default only ones on this machine or the local network, so an outsider
+// can't point QR codes somewhere else.
 export const TRUST_PROXY = (() => {
   const raw = process.env.TRUST_PROXY;
   if (raw === undefined || raw === "") return "loopback, linklocal, uniquelocal";

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -12,6 +12,7 @@ import {
   UPLOADS_DIR,
   FRONTEND_DIR,
   CORS_ORIGIN,
+  TRUST_PROXY,
 } from "./config.js";
 // Importing the database opens it and runs migrations before any route module
 // is loaded.
@@ -29,8 +30,9 @@ const app = express();
 const server = createServer(app);
 
 // Honour X-Forwarded-* so request-derived URLs (QR codes) are correct when the
-// container sits behind a reverse proxy.
-app.set("trust proxy", true);
+// container sits behind a reverse proxy. Scoped to trusted upstreams — see
+// TRUST_PROXY in config.js.
+app.set("trust proxy", TRUST_PROXY);
 
 // Same-origin in the packaged deployment, so CORS is only wired up when an
 // origin is explicitly configured (i.e. running against the Vite dev server).

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -29,9 +29,8 @@ import { setupWebSocket } from "./websocket/handler.js";
 const app = express();
 const server = createServer(app);
 
-// Honour X-Forwarded-* so request-derived URLs (QR codes) are correct when the
-// container sits behind a reverse proxy. Scoped to trusted upstreams — see
-// TRUST_PROXY in config.js.
+// Lets QR codes use the address guests actually came in on when a reverse
+// proxy sits in front.
 app.set("trust proxy", TRUST_PROXY);
 
 // Same-origin in the packaged deployment, so CORS is only wired up when an

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,12 @@ services:
     ports:
       # The API, the WebSocket endpoint, the uploaded images and the frontend
       # are all served from this one port.
-      - "21000:3000"
+      #
+      # Bound to loopback so only Caddy, running on the host, can reach it.
+      # Without this the app is reachable from the whole LAN, bypassing the
+      # proxy — and since QR code URLs are derived from request headers, a
+      # request that skips Caddy can set those headers itself.
+      - "127.0.0.1:21000:3000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
@@ -33,3 +38,26 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+# When Caddy moves into a container of its own — a separate stack, not a service
+# here — join it on a shared external network instead of publishing a port. The
+# app is then unreachable from outside Docker entirely, and Caddy addresses it
+# by container name.
+#
+# Create the network once, outside either stack:
+#
+#     docker network create edge
+#
+# Then drop the `ports` block above and add to this file:
+#
+#     services:
+#       home-bar:
+#         networks: [edge]
+#     networks:
+#       edge:
+#         external: true
+#
+# Caddy's own compose file joins the same network, and its Caddyfile becomes:
+#
+#     bar.example.com {
+#         reverse_proxy home-bar:3000
+#     }

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,26 +5,19 @@ services:
     restart: unless-stopped
     init: true
     ports:
-      # The API, the WebSocket endpoint, the uploaded images and the frontend
-      # are all served from this one port.
-      #
-      # Bound to loopback so only Caddy, running on the host, can reach it.
-      # Without this the app is reachable from the whole LAN, bypassing the
-      # proxy — and since QR code URLs are derived from request headers, a
-      # request that skips Caddy can set those headers itself.
+      # Everything is served on this one port. Only this machine can reach it,
+      # so put a reverse proxy in front to expose the bar.
       - "127.0.0.1:21000:3000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
     environment:
-      # Set these to run as an unprivileged user; ownership of ./data and
-      # ./uploads is adjusted on start. Leave unset to keep running as root,
-      # which is how existing bind-mounted data was created.
+      TZ: Europe/Copenhagen
+      # Run as a normal user instead of root. File ownership is fixed on start.
       # PUID: 1000
       # PGID: 1000
-      TZ: Europe/Copenhagen
-      # Only needed if the address guests reach the bar on differs from the one
-      # the request arrives with. Otherwise QR codes use the requesting host.
+      # Set this if the web address guests use differs from the one the bar
+      # is reached on. QR codes use it.
       # PUBLIC_URL: https://bar.example.com
     healthcheck:
       test:
@@ -38,26 +31,5 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
-# When Caddy moves into a container of its own — a separate stack, not a service
-# here — join it on a shared external network instead of publishing a port. The
-# app is then unreachable from outside Docker entirely, and Caddy addresses it
-# by container name.
-#
-# Create the network once, outside either stack:
-#
-#     docker network create edge
-#
-# Then drop the `ports` block above and add to this file:
-#
-#     services:
-#       home-bar:
-#         networks: [edge]
-#     networks:
-#       edge:
-#         external: true
-#
-# Caddy's own compose file joins the same network, and its Caddyfile becomes:
-#
-#     bar.example.com {
-#         reverse_proxy home-bar:3000
-#     }
+# If the reverse proxy is moved into its own container, remove the ports block
+# above and share a network with it instead. See the README.


### PR DESCRIPTION
Binds the published port to `127.0.0.1` so only a reverse proxy on the same host can reach the app, and narrows `trust proxy` from unconditional `true` to loopback and private addresses.

The QR endpoint derives its base URL from request headers, so an app reachable outside the proxy could be handed forged `X-Forwarded-*` headers and made to encode a QR code pointing elsewhere.

Verified against a running container:

| Case | Result |
| --- | --- |
| Proxy on the Docker bridge (private IP) | headers trusted → `https://bar.example.com/...` |
| No forwarded headers | falls back to request host |
| `PUBLIC_URL` set | overrides both |

Also documents the shared external network setup for when Caddy moves into its own container stack.

Closes #29