### PR TITLE
Add CLAUDE.md and shorten comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Working on the home bar
+
+A small self-hosted bar. Guests browse a menu and order drinks; the bartender
+works the queue. Orders update live.
+
+It is used by guests and hosts at a party, not by developers. That shapes most
+of the rules below.
+
+## Writing style
+
+**Comments: short, plain, and about *why*.** One line beats a paragraph. Put
+longer reasoning in the commit message or pull request, where it isn't in the
+way of the code.
+
+Avoid jargon in comments and in anything a person using the app will read. Say
+"only this machine" rather than "loopback", "safe to run again" rather than
+"idempotent". Assume the reader is not a programmer.
+
+Every visible string needs both English and Danish — see
+`frontend/src/utils/translations.ts`. Flag Danish wording for review rather than
+guessing at it.
+
+## Shape of the thing
+
+One container serves everything on one port: the API at `/api`, live updates,
+drink photos at `/uploads`, and the web pages. There is no separate web server
+and no proxy between the parts.
+
+That is deliberate. The previous split-container setup kept drifting out of sync
+with the code, and three separate bugs came from it. Keep it on one origin.
+
+The database is SQLite, which is the right fit here and not something to
+outgrow. Photos are files on disk. Both live in mounted folders (`data/`,
+`uploads/`) that must survive an upgrade.
+
+## Database changes
+
+Add a dated `.sql` file to `backend/src/db/migrations/`. It is applied once on
+the next start and recorded by filename, oldest first.
+
+Never edit a migration that has already run — the change would be silently
+skipped on any database that has seen it. Add a new one instead.
+
+Real installs have data in them. Anything that changes the schema should be
+tried against a copy of a real database first, not just an empty one.
+
+## Branches and releases
+
+`staging` is where work lands. Open a pull request into it, one per issue, and
+keep them small enough to read in one sitting.
+
+`main` is what the bar runs. When `staging` is ready, squash-merge it into
+`main`, which publishes the `latest` image. `staging` is then deleted and branched
+fresh from `main` next time — so merge or retarget any open pull requests before
+cutting a release, because deleting a branch closes anything aimed at it.
+
+Images: `latest` from `main`, `staging` from `staging`, `sha-…` for pinning.
+Test the `staging` image against a copy of the real data before releasing.
+
+## Local checks
+
+`docker compose -f compose.yaml -f compose.dev.yaml up --build` builds and runs
+the real image from a checkout.
+
+For a change that touches startup, the database, or file handling, run the image
+against a copy of real data and confirm the container reports healthy — not just
+that it starts.
+
+## Don't commit
+
+`.inspect/` holds copies of real data for debugging. It is ignored by git and by
+the image build, and must stay that way: it contains guests' names and password
+hashes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # syntax=docker/dockerfile:1
 
-# Builds a single image that serves the API, the WebSocket endpoint, the
-# uploaded images and the built frontend from one port.
+# One image that serves the whole app on a single port.
 
-# ---- Frontend build -------------------------------------------------------
-# Pure JS toolchain, so alpine is fine and fast here.
+# ---- Build the web pages --------------------------------------------------
 FROM node:22-alpine AS frontend
 WORKDIR /build
 
@@ -14,10 +12,9 @@ RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
-# ---- Backend dependencies -------------------------------------------------
-# Debian rather than alpine: better-sqlite3 and bcrypt publish prebuilt glibc
-# binaries, so this normally downloads rather than compiles. The toolchain is
-# installed anyway so the build still succeeds on platforms without prebuilts.
+# ---- Install server packages ----------------------------------------------
+# Debian, because two packages ship ready-built for it. The compiler is here
+# as a fallback for platforms without a ready-built version.
 FROM node:22-slim AS backend-deps
 WORKDIR /build
 
@@ -43,8 +40,7 @@ COPY backend/package.json ./package.json
 COPY backend/src ./src
 COPY --from=frontend /build/dist ./public
 
-# Mount points for the persistent data. Declared so the paths exist and are
-# writable even when nothing is mounted over them.
+# Where the database and photos live.
 RUN mkdir -p /app/data /app/uploads && chown -R node:node /app/data /app/uploads
 
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -52,7 +48,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 3000
 
-# No curl or wget in the slim image, so the check is made with Node itself.
+# Tells Docker whether the bar is actually working, not just running.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/api/health').then(r=>{if(!r.ok)throw 0;process.exit(0)}).catch(()=>process.exit(1))"
 

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -6,40 +6,31 @@ dotenv.config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Repository/app root: one level above src/
 const APP_ROOT = path.resolve(__dirname, "..");
 
 export const PORT = Number(process.env.PORT) || 3000;
 
 export const NODE_ENV = process.env.NODE_ENV || "development";
 
-// Existing deployments bind-mount their database here. Do not change the
-// default without a migration path for them.
+// Existing installs keep their database here. Changing this strands it.
 export const DB_PATH = path.resolve(
   process.env.DB_PATH || path.join(APP_ROOT, "data", "bar.db")
 );
 
-// Uploaded drink images. Served at /uploads and written to by multer.
+// Drink photos.
 export const UPLOADS_DIR = path.resolve(
   process.env.UPLOADS_DIR || path.join(APP_ROOT, "uploads")
 );
 
-// Built frontend assets. In the published image these sit next to the backend;
-// in local development the frontend is served by Vite instead and this path
-// simply won't exist, which is handled at startup.
+// The built web pages. Missing during development, where Vite serves them.
 export const FRONTEND_DIR = path.resolve(
   process.env.FRONTEND_DIR || path.join(APP_ROOT, "public")
 );
 
-// Only needed when the frontend is served from a different origin, i.e. `npm run
-// dev` against the Vite dev server. In the single-container deployment
-// everything is same-origin and CORS is left off entirely.
+// Only needed in development, when the pages come from a different address.
 export const CORS_ORIGIN = process.env.CORS_ORIGIN || process.env.FRONTEND_URL;
 
-// Absolute base URL used when generating QR codes. Left unset, it is derived
-// from the incoming request, which is correct for both direct access and a
-// reverse proxy that sets X-Forwarded-*. Set it explicitly when the address
-// guests use differs from the one the bartender's browser sees.
+// Web address to put in QR codes. Worked out from the request if unset.
 export const PUBLIC_URL = (
   process.env.PUBLIC_URL ||
   process.env.FRONTEND_URL ||

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -13,9 +13,7 @@ export const db = new Database(DB_PATH);
 db.pragma("journal_mode = WAL");
 db.pragma("foreign_keys = ON");
 
-// Migrations run before anything imports the routes, so the server never serves
-// traffic against a stale schema. This replaces the old one-shot `db-init`
-// container, which had to exit and therefore showed up as a dead container.
+// Brought up to date before anything starts using it.
 runMigrations(db);
 
 export function closeDatabase() {

--- a/backend/src/db/migrate.js
+++ b/backend/src/db/migrate.js
@@ -8,15 +8,11 @@ const SCHEMA_FILE = path.join(__dirname, "schema.sql");
 const MIGRATIONS_DIR = path.join(__dirname, "migrations");
 
 /**
- * Applies the base schema and any migrations the database hasn't seen yet.
- *
- * Safe to run on every boot, and safe to run against databases created by the
- * older standalone `init-db` script: the bookkeeping table and the filenames
- * recorded in it are unchanged, so previously applied migrations are skipped.
+ * Brings the database up to date. Runs on every start; does nothing if there
+ * is nothing new to apply.
  */
 export function runMigrations(db) {
-  // Every statement in schema.sql is CREATE ... IF NOT EXISTS, so this is a
-  // no-op against an existing database.
+  // Creates the tables only if they are missing.
   db.exec(fs.readFileSync(SCHEMA_FILE, "utf8"));
 
   db.exec(`
@@ -32,8 +28,7 @@ export function runMigrations(db) {
   const isApplied = db.prepare("SELECT 1 FROM migrations WHERE name = ?");
   const markApplied = db.prepare("INSERT INTO migrations (name) VALUES (?)");
 
-  // Filenames are date-prefixed, so lexical order is chronological order.
-  // readdirSync order is not guaranteed across filesystems, hence the sort.
+  // Sorted so the date-named files apply oldest first.
   const files = fs
     .readdirSync(MIGRATIONS_DIR)
     .filter((f) => f.endsWith(".sql"))
@@ -47,16 +42,14 @@ export function runMigrations(db) {
     const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8");
 
     try {
-      // Apply and record atomically: a failure leaves no partial bookkeeping.
+      // All or nothing, so a failure leaves no half-applied change.
       db.transaction(() => {
         db.exec(sql);
         markApplied.run(file);
       })();
     } catch (error) {
-      // A database that predates the migrations table may already carry these
-      // columns. CREATE statements in migrations are all IF NOT EXISTS, so the
-      // only idempotency gap is ALTER TABLE ADD COLUMN. Treat that as already
-      // applied rather than crash-looping on boot.
+      // An older database may already have this change. Record it instead of
+      // failing to start.
       if (/duplicate column name/i.test(error.message)) {
         console.warn(
           `Migration ${file} was already present in the schema; recording it as applied.`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,9 +6,8 @@ UPLOADS_DIR="${UPLOADS_DIR:-/app/uploads}"
 
 mkdir -p "$DATA_DIR" "$UPLOADS_DIR"
 
-# The container runs as root by default, which matches how existing bind-mounted
-# data directories were created. Set PUID/PGID to run as an unprivileged user
-# instead; ownership of the data is adjusted to match so nothing breaks.
+# Runs as root unless PUID/PGID are set, which matches how existing data was
+# created. When they are set, fix ownership first so nothing breaks.
 if [ "$(id -u)" = "0" ] && [ -n "${PUID}${PGID}" ]; then
     uid="${PUID:-1000}"
     gid="${PGID:-1000}"


### PR DESCRIPTION
Adds a CLAUDE.md recording the conventions settled on so far — writing style, the one-origin architecture and the reasoning behind it, how migrations work, the branch and release flow, and what must not be committed.

Also applies the writing rule to the comments added with the single-image work, which had grown into paragraphs. Comment lines in `config.js` drop from 17 to 8; `compose.yaml` loses roughly half its comment bulk. Nothing that was load-bearing is lost — the longer reasoning lives in the commit messages and PR descriptions instead.

Rebuilt and ran the image afterwards: healthy, six migrations apply on a fresh database.