### PR TITLE
Clear only this app's saved settings when signing out

### DIFF
--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useApp } from "../context/AppContext";
 import LoginForm from "./LoginForm";
+import { ACTIVITY_KEY } from "../hooks/useSessionManager";
 
 const QRRedirect: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -88,7 +89,7 @@ const QRRedirect: React.FC = () => {
       setUserType("guest");
       
       // Update session activity timestamp
-      localStorage.setItem("homeBarSystem_lastActivity", Date.now().toString());
+      localStorage.setItem(ACTIVITY_KEY, Date.now().toString());
       
       // The current bar should already be set from the earlier fetchBarInfo call,
       // but let's make sure it has the latest info

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -134,6 +134,10 @@ export const useApp = () => {
 
 const API_BASE = "/api";
 
+// Everything this app saves in the browser starts with this, so signing out
+// can clear its own things without touching anything else on the site.
+export const STORAGE_PREFIX = "homeBarSystem_";
+
 const STORAGE_KEYS = {
   userType: "homeBarSystem_userType",
   currentBar: "homeBarSystem_currentBar",
@@ -256,7 +260,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
       language: "en",
     });
     setLoginForm({ password: "", name: "" });
-    localStorage.clear();
+
+    Object.keys(localStorage)
+      .filter((key) => key.startsWith(STORAGE_PREFIX))
+      .forEach((key) => localStorage.removeItem(key));
   };
 
   // Session validation effect

--- a/frontend/src/hooks/useSessionManager.ts
+++ b/frontend/src/hooks/useSessionManager.ts
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useApp } from "../context/AppContext";
 
 const SESSION_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
-const ACTIVITY_KEY = "homeBarSystem_lastActivity";
+export const ACTIVITY_KEY = "homeBarSystem_lastActivity";
 
 export const useSessionManager = () => {
   const { setUserType, setCurrentBar, setCustomerName, setLoginForm } =


### PR DESCRIPTION
Closes #31.

Signing out called `localStorage.clear()`, which wipes everything the browser has stored for the whole site rather than just the bar's own settings. On a shared domain that is somebody else's data. It now removes only keys carrying the app's prefix — which also catches `homeBarSystem_lastActivity`, previously left behind on sign-out.

Also exports the activity key instead of repeating the literal in two files, where the two could drift apart silently.

The other items on this issue turned out to be done already: the duplicated `EditCategoryFormProps` and the unused imports were fixed in #36 when linting ran for the first time, and the `WS_PORT` remnants are gone apart from one deliberate note in the README explaining the migration. The remaining `any` types stay with #27 and #37 as planned.