### PR TITLE
Stop uploaded photos piling up

### DIFF
--- a/backend/src/routes/drinks.js
+++ b/backend/src/routes/drinks.js
@@ -2,6 +2,7 @@ import express from "express";
 import multer from "multer";
 import path from "path";
 import fs from "fs";
+import { deletePhotoIfUnused } from "../uploads.js";
 
 export default function createDrinkRoutes({ db, uploadsDir }) {
   const router = express.Router();
@@ -256,6 +257,13 @@ router.put("/:drinkId", (req, res) => {
     if (imageUrl !== undefined) {
       updates.push("image_url = ?");
       values.push(imageUrl || null);
+
+      // The photo being replaced is no longer needed.
+      if (existingDrink.image_url && existingDrink.image_url !== imageUrl) {
+        deletePhotoIfUnused({ db, uploadsDir }, existingDrink.image_url, {
+          exceptDrinkId: Number(drinkId),
+        });
+      }
     }
     if (recipe !== undefined) {
       updates.push("recipe = ?");
@@ -374,17 +382,10 @@ router.delete("/:drinkId", (req, res) => {
       return res.status(404).json({ error: "Drink not found" });
     }
 
-    // Delete associated image file if it exists. basename() keeps a crafted
-    // image_url from reaching outside the uploads directory.
-    if (drink.image_url && drink.image_url.startsWith("/uploads/")) {
-      const imagePath = path.join(
-        uploadsDir,
-        path.basename(drink.image_url)
-      );
-      if (fs.existsSync(imagePath)) {
-        fs.unlinkSync(imagePath);
-      }
-    }
+    // Remove its photo, unless another drink is using the same one.
+    deletePhotoIfUnused({ db, uploadsDir }, drink.image_url, {
+      exceptDrinkId: Number(drinkId),
+    });
 
     // Delete the drink
     const stmt = db.prepare("DELETE FROM drinks WHERE id = ? AND bar_id = ?");

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -9,10 +9,29 @@ import {
 } from "./config.js";
 import { openDatabase, closeDatabase } from "./db/index.js";
 import { createApp } from "./app.js";
+import { sweepUnusedPhotos } from "./uploads.js";
 
 const db = openDatabase(DB_PATH);
 const app = createApp({ db });
 const server = createServer(app);
+
+// A photo is saved before its drink is, so an abandoned form leaves one
+// behind. Clear out anything old that nothing refers to.
+const SWEEP_EVERY_MS = 24 * 60 * 60 * 1000;
+
+const sweepPhotos = () => {
+  try {
+    const removed = sweepUnusedPhotos({ db, uploadsDir: UPLOADS_DIR });
+    if (removed.length) {
+      console.log(`Removed ${removed.length} unused photo(s)`);
+    }
+  } catch (error) {
+    console.error("Could not tidy up photos:", error);
+  }
+};
+
+sweepPhotos();
+setInterval(sweepPhotos, SWEEP_EVERY_MS).unref();
 
 server.listen(PORT, () => {
   console.log(`🍸 Bar running on port ${PORT}`);

--- a/backend/src/uploads.js
+++ b/backend/src/uploads.js
@@ -1,0 +1,76 @@
+import fs from "fs";
+import path from "path";
+
+const UPLOAD_PREFIX = "/uploads/";
+
+/** True for photos we store ourselves, as opposed to a web address. */
+export function isStoredPhoto(imageUrl) {
+  return typeof imageUrl === "string" && imageUrl.startsWith(UPLOAD_PREFIX);
+}
+
+/**
+ * Deletes a photo, unless some other drink is still using it. Only ever
+ * touches files inside the photos folder.
+ */
+export function deletePhotoIfUnused(
+  { db, uploadsDir },
+  imageUrl,
+  { exceptDrinkId = null } = {}
+) {
+  if (!isStoredPhoto(imageUrl)) return false;
+
+  const stillUsed = db
+    .prepare(
+      `SELECT 1 FROM drinks
+       WHERE image_url = ? AND (? IS NULL OR id != ?)
+       LIMIT 1`
+    )
+    .get(imageUrl, exceptDrinkId, exceptDrinkId);
+
+  if (stillUsed) return false;
+
+  const filePath = path.join(uploadsDir, path.basename(imageUrl));
+  if (!fs.existsSync(filePath)) return false;
+
+  fs.unlinkSync(filePath);
+  return true;
+}
+
+/**
+ * Removes photos no drink refers to. A photo is uploaded before the drink is
+ * saved, so anything recent is left alone in case someone is still filling in
+ * the form.
+ */
+export function sweepUnusedPhotos({
+  db,
+  uploadsDir,
+  minimumAgeMs = 24 * 60 * 60 * 1000,
+  now = Date.now(),
+}) {
+  if (!fs.existsSync(uploadsDir)) return [];
+
+  const inUse = new Set(
+    db
+      .prepare("SELECT DISTINCT image_url FROM drinks WHERE image_url IS NOT NULL")
+      .all()
+      .map((row) => row.image_url)
+      .filter(isStoredPhoto)
+      .map((url) => path.basename(url))
+  );
+
+  const removed = [];
+
+  for (const name of fs.readdirSync(uploadsDir)) {
+    if (inUse.has(name)) continue;
+
+    const filePath = path.join(uploadsDir, name);
+    const stats = fs.statSync(filePath);
+    if (!stats.isFile()) continue;
+    if (now - stats.mtimeMs < minimumAgeMs) continue;
+
+    fs.unlinkSync(filePath);
+    removed.push(name);
+  }
+
+  return removed;
+}

--- a/backend/tests/uploads.test.js
+++ b/backend/tests/uploads.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import fs from "fs";
+import path from "path";
+
+import { deletePhotoIfUnused, sweepUnusedPhotos } from "../src/uploads.js";
+import { makeTestApp, cleanUpTempDirs, seedBar } from "./helpers.js";
+
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64"
+);
+
+afterAll(cleanUpTempDirs);
+
+describe("tidying up photos", () => {
+  let app;
+  let db;
+  let uploadsDir;
+  let barId;
+
+  beforeEach(() => {
+    ({ app, db, uploadsDir } = makeTestApp());
+    ({ barId } = seedBar(db));
+  });
+
+  const photoOnDisk = (name) => fs.existsSync(path.join(uploadsDir, name));
+
+  const uploadPhoto = async () => {
+    const res = await request(app)
+      .post("/api/drinks/upload-image")
+      .attach("image", PNG, { filename: "drink.png", contentType: "image/png" });
+    return res.body;
+  };
+
+  const createDrink = (imageUrl, title = "Negroni") =>
+    request(app).post("/api/drinks").send({ barId, title, recipe: "gin", imageUrl });
+
+  it("removes the old photo when a drink gets a new one", async () => {
+    const first = await uploadPhoto();
+    const drink = await createDrink(first.imageUrl);
+    const second = await uploadPhoto();
+
+    await request(app)
+      .put(`/api/drinks/${drink.body.id}`)
+      .send({ barId, imageUrl: second.imageUrl });
+
+    expect(photoOnDisk(first.filename)).toBe(false);
+    expect(photoOnDisk(second.filename)).toBe(true);
+  });
+
+  it("keeps the photo when a drink is changed but its photo is not", async () => {
+    const photo = await uploadPhoto();
+    const drink = await createDrink(photo.imageUrl);
+
+    await request(app)
+      .put(`/api/drinks/${drink.body.id}`)
+      .send({ barId, title: "Renamed", imageUrl: photo.imageUrl });
+
+    expect(photoOnDisk(photo.filename)).toBe(true);
+  });
+
+  it("keeps a photo two drinks share", async () => {
+    const photo = await uploadPhoto();
+    const one = await createDrink(photo.imageUrl, "First");
+    await createDrink(photo.imageUrl, "Second");
+
+    await request(app).delete(`/api/drinks/${one.body.id}`).send({ barId });
+
+    expect(photoOnDisk(photo.filename)).toBe(true);
+  });
+
+  it("removes the photo when the last drink using it goes", async () => {
+    const photo = await uploadPhoto();
+    const one = await createDrink(photo.imageUrl, "First");
+    const two = await createDrink(photo.imageUrl, "Second");
+
+    await request(app).delete(`/api/drinks/${one.body.id}`).send({ barId });
+    await request(app).delete(`/api/drinks/${two.body.id}`).send({ barId });
+
+    expect(photoOnDisk(photo.filename)).toBe(false);
+  });
+
+  it("leaves a photo held elsewhere on the web alone", () => {
+    const removed = deletePhotoIfUnused(
+      { db, uploadsDir },
+      "https://example.com/negroni.jpg"
+    );
+
+    expect(removed).toBe(false);
+  });
+
+  it("will not reach outside the photos folder", () => {
+    const outside = path.join(uploadsDir, "..", "important.txt");
+    fs.writeFileSync(outside, "keep me");
+
+    deletePhotoIfUnused({ db, uploadsDir }, "/uploads/../important.txt");
+
+    expect(fs.existsSync(outside)).toBe(true);
+    fs.rmSync(outside, { force: true });
+  });
+});
+
+describe("the daily sweep", () => {
+  let db;
+  let uploadsDir;
+  let barId;
+
+  beforeEach(() => {
+    ({ db, uploadsDir, barId } = (() => {
+      const t = makeTestApp();
+      return { ...t, ...seedBar(t.db) };
+    })());
+  });
+
+  const writePhoto = (name, ageMs = 0) => {
+    const filePath = path.join(uploadsDir, name);
+    fs.writeFileSync(filePath, "photo");
+    if (ageMs) {
+      const when = new Date(Date.now() - ageMs);
+      fs.utimesSync(filePath, when, when);
+    }
+    return filePath;
+  };
+
+  it("removes an old photo nothing refers to", () => {
+    writePhoto("drink-orphan.png", 48 * 60 * 60 * 1000);
+
+    const removed = sweepUnusedPhotos({ db, uploadsDir });
+
+    expect(removed).toEqual(["drink-orphan.png"]);
+    expect(fs.existsSync(path.join(uploadsDir, "drink-orphan.png"))).toBe(false);
+  });
+
+  it("leaves a recent photo alone, in case a drink is still being written", () => {
+    writePhoto("drink-just-uploaded.png");
+
+    const removed = sweepUnusedPhotos({ db, uploadsDir });
+
+    expect(removed).toEqual([]);
+    expect(
+      fs.existsSync(path.join(uploadsDir, "drink-just-uploaded.png"))
+    ).toBe(true);
+  });
+
+  it("leaves photos that drinks are using, however old", () => {
+    writePhoto("drink-in-use.png", 90 * 24 * 60 * 60 * 1000);
+    db.prepare(
+      "INSERT INTO drinks (bar_id, title, recipe, image_url) VALUES (?, 'Old', 'gin', '/uploads/drink-in-use.png')"
+    ).run(barId);
+
+    const removed = sweepUnusedPhotos({ db, uploadsDir });
+
+    expect(removed).toEqual([]);
+  });
+
+  it("copes with the photos folder not being there yet", () => {
+    expect(() =>
+      sweepUnusedPhotos({ db, uploadsDir: path.join(uploadsDir, "nope") })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #32.

Photos were only removed when their drink was deleted (`unlink` appeared in exactly one place), so two paths leaked files:

1. **Changing a drink's photo** — the update route swapped `image_url` and left the old file.
2. **Abandoning the form** — the photo is stored and its address returned *before* the drink is saved, so closing without saving strands it.

## What changed

Replacing a photo now removes the previous one, **unless another drink is using the same file** — that check is new, and applies on delete too, where it was previously missing.

As a backstop, anything unreferenced and older than a day is cleared out on start and once a day after. The age threshold matters: a photo exists before its drink does, so sweeping recent files would delete one out from under someone still filling in the form.

## Verified against the real data

Run against a copy of your photos folder:

```
files before: 143
would remove:   7   (exactly the orphans identified earlier)
files after:  136
referenced photos now missing: 0
```

Also ran the built container against a copy: healthy, photos serving, and the sweep correctly declined to remove anything because the copied files were newer than the threshold.

## Tests

11 new, 59 total. They cover replacing a photo, changing a drink without touching its photo, two drinks sharing one file, removing it only when the last user goes, leaving external web addresses alone, and refusing to reach outside the photos folder. The sweep is covered for old-and-unused, recent-and-unused, old-but-in-use, and a missing folder.