### PR TITLE
Have the pages use the shared types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,15 @@ The server is TypeScript, built with `npm run build` and run from `dist/`.
 
 The shapes the API sends live in `shared/types.d.ts` and are imported by both
 halves, so changing one without the other is a build error. It holds types only
-and disappears when built, which is why neither half has to bundle it.
+and disappears when built, which is why neither half has to bundle it. Both
+Dockerfile build stages need `COPY shared ../shared` for that to resolve.
+
+The pages get them through `frontend/src/types.ts`, which is also where a couple
+are re-named to suit the pages. Nothing in `frontend/src` should write out an
+API shape by hand — that is how the two sides drifted apart before.
+
+SQLite has no boolean, so flags arrive as `0` or `1`. Type them as `Flag` and
+compare with `=== 1`; do not pretend they are booleans.
 
 Routes share a few pieces rather than repeating them: `route()` turns a thrown
 error into the right reply, `HttpError` carries the status, `findBar`/`findDrink`

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
 COPY frontend/ ./
+# The API shapes, shared with the server. Types only, so nothing is bundled.
+COPY shared ../shared
 RUN npm run build
 
 # ---- Install server packages ----------------------------------------------

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,13 +3,21 @@ import bcrypt from "bcrypt";
 
 import type { UserType } from "../../../shared/types.js";
 import { HttpError, requireId, requireText, route } from "../http.js";
-import { findBar, type BarRow, type Db } from "../db/queries.js";
+import { findBar, publicBar, type BarRow, type Db } from "../db/queries.js";
 
 /** Which stored password a sign-in should be checked against. */
 const PASSWORD_FIELD = {
   bartender: "bartender_password_hash",
   guest: "guest_password_hash",
 } as const satisfies Record<UserType, keyof BarRow>;
+
+/**
+ * The reply to a sign-in. The whole bar goes back, so the pages never have to
+ * piece one together from loose fields and lose its settings doing it.
+ */
+function signedInAs(bar: BarRow, userType: UserType) {
+  return { success: true, userType, bar: publicBar(bar) };
+}
 
 export default function createAuthRoutes(db: Db): Router {
   const router = express.Router();
@@ -32,13 +40,7 @@ export default function createAuthRoutes(db: Db): Router {
     route(async (req, res) => {
       const bar = await signIn(req.body, "bartender");
 
-      res.json({
-        success: true,
-        barId: bar.id,
-        barName: bar.name,
-        language: bar.language,
-        userType: "bartender",
-      });
+      res.json(signedInAs(bar, "bartender"));
     })
   );
 
@@ -51,14 +53,7 @@ export default function createAuthRoutes(db: Db): Router {
       });
       const bar = await signIn(req.body, "guest");
 
-      res.json({
-        success: true,
-        barId: bar.id,
-        barName: bar.name,
-        language: bar.language,
-        customerName,
-        userType: "guest",
-      });
+      res.json({ ...signedInAs(bar, "guest"), customerName });
     })
   );
 
@@ -69,13 +64,7 @@ export default function createAuthRoutes(db: Db): Router {
       const userType = requireText(req.body, "userType");
       const bar = findBar(db, barId);
 
-      res.json({
-        success: true,
-        barId: bar.id,
-        barName: bar.name,
-        language: bar.language,
-        userType,
-      });
+      res.json(signedInAs(bar, userType as UserType));
     })
   );
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -100,12 +100,9 @@ export default function createBarRoutes({
         language
       );
 
-      res.status(201).json({
-        id: Number(lastInsertRowid),
-        name,
-        language,
-        message: "Bar created successfully",
-      });
+      // The whole bar goes back, settings and all, so the pages can hold on to
+      // it as-is.
+      res.status(201).json(publicBar(findBar(db, Number(lastInsertRowid))));
     })
   );
 

--- a/backend/src/routes/drinks.ts
+++ b/backend/src/routes/drinks.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 
 import type {
   Drink,
+  DrinkAnalytics,
   DrinkForGuest,
   DrinkWithCategory,
 } from "../../../shared/types.js";
@@ -269,7 +270,7 @@ export default function createDrinkRoutes({
     route((req, res) => {
       const barId = idParam(req, "barId");
 
-      res.json({
+      const report = {
         popularDrinks: all<{ drink_title: string; order_count: number }>(
           db,
           `SELECT drink_title, COUNT(*) AS order_count FROM orders
@@ -287,7 +288,9 @@ export default function createDrinkRoutes({
           "SELECT COUNT(*) AS n FROM drinks WHERE bar_id = ? AND in_stock = 1",
           barId
         ),
-      });
+      } satisfies DrinkAnalytics;
+
+      res.json(report);
     })
   );
 

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -1,6 +1,11 @@
 import express, { type Router } from "express";
 
-import type { Order, OrderForBartender } from "../../../shared/types.js";
+import type {
+  Order,
+  OrderAnalytics,
+  OrderForBartender,
+  OrderStatus,
+} from "../../../shared/types.js";
 import {
   HttpError,
   idParam,
@@ -217,7 +222,7 @@ export default function createOrderRoutes(db: Db): Router {
           since
         )?.avg_per_day ?? 0;
 
-      res.json({
+      const report = {
         totalOrders: count(
           db,
           "SELECT COUNT(*) AS n FROM orders WHERE bar_id = ?",
@@ -244,7 +249,7 @@ export default function createOrderRoutes(db: Db): Router {
           barId
         ),
         peakHours,
-        statusDistribution: all<{ status: string; count: number }>(
+        statusDistribution: all<{ status: OrderStatus; count: number }>(
           db,
           `SELECT status, COUNT(*) AS count FROM orders
            WHERE bar_id = ? AND created_at >= datetime('now', ?)
@@ -254,7 +259,9 @@ export default function createOrderRoutes(db: Db): Router {
         ),
         averageOrdersPerDay: Math.round(averagePerDay * 10) / 10,
         period: `${days} days`,
-      });
+      } satisfies OrderAnalytics;
+
+      res.json(report);
     })
   );
 

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Express } from "express";
+import request from "supertest";
+
+import { makeTestApp, cleanUpTempDirs } from "./helpers.js";
+
+afterAll(cleanUpTempDirs);
+
+// The settings page reads the bar it was handed, so a reply that leaves fields
+// out silently turns settings back off. That is what went wrong before.
+describe("signing in", () => {
+  let app: Express;
+  let barId: number;
+
+  beforeAll(async () => {
+    app = makeTestApp().app;
+
+    const created = await request(app).post("/api/bars").send({
+      name: "Garden Bar",
+      bartenderPassword: "shaker",
+      guestPassword: "gin",
+      language: "da",
+    });
+
+    expect(created.status).toBe(201);
+    barId = created.body.id;
+
+    await request(app)
+      .put(`/api/bars/${barId}`)
+      .send({ skipApproval: true })
+      .expect(200);
+  });
+
+  it("hands back the whole bar when the bar is made", async () => {
+    const res = await request(app).post("/api/bars").send({
+      name: "Kitchen Bar",
+      bartenderPassword: "shaker",
+      guestPassword: "gin",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      name: "Kitchen Bar",
+      language: "en",
+      skip_approval: 0,
+    });
+    expect(res.body.created_at).toBeTruthy();
+  });
+
+  for (const [who, body] of [
+    ["bartender", { password: "shaker" }],
+    ["guest", { password: "gin", customerName: "Ada" }],
+  ] as const) {
+    it(`hands the ${who} the whole bar, settings and all`, async () => {
+      const res = await request(app)
+        .post(`/api/auth/${who}`)
+        .send({ barId, ...body });
+
+      expect(res.status).toBe(200);
+      expect(res.body.userType).toBe(who);
+      expect(res.body.bar).toMatchObject({
+        id: barId,
+        name: "Garden Bar",
+        language: "da",
+        skip_approval: 1,
+      });
+    });
+  }
+
+  it("never sends the stored passwords back", async () => {
+    const res = await request(app)
+      .post("/api/auth/bartender")
+      .send({ barId, password: "shaker" });
+
+    expect(JSON.stringify(res.body)).not.toMatch(/password_hash/);
+  });
+
+  it("turns away the wrong password", async () => {
+    const res = await request(app)
+      .post("/api/auth/bartender")
+      .send({ barId, password: "wrong" });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/src/components/BarCreator.tsx
+++ b/frontend/src/components/BarCreator.tsx
@@ -43,12 +43,8 @@ const BarCreator: React.FC<BarCreatorProps> = ({ onBack, onSuccess }) => {
         }),
       });
 
-      setCurrentBar({
-        id: data.id,
-        name: data.name,
-        language: data.language,
-      });
-      setLanguage(data.language as "en" | "da");
+      setCurrentBar(data);
+      setLanguage(data.language);
       setUserType("bartender");
 
       onSuccess();

--- a/frontend/src/components/BarSelector.tsx
+++ b/frontend/src/components/BarSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { RefreshCw, Plus } from "lucide-react";
-import { useApp, Bar } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 
 interface BarSelectorProps {

--- a/frontend/src/components/CategoriesTab.tsx
+++ b/frontend/src/components/CategoriesTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Plus, Edit3, Trash2, Tag } from "lucide-react";
-import { useApp, Category } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Category } from "../types";
 import { useTranslation } from "../utils/translations";
 
 const CategoriesTab: React.FC = () => {

--- a/frontend/src/components/CustomerInterface.tsx
+++ b/frontend/src/components/CustomerInterface.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Clock, CheckCircle, XCircle, Coffee, Check } from "lucide-react";
-import { useApp, Drink } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { useSessionManager } from "../hooks/useSessionManager";
 import { useLiveUpdates } from "../context/LiveUpdatesContext";

--- a/frontend/src/components/DrinkCard.tsx
+++ b/frontend/src/components/DrinkCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Star } from "lucide-react";
-import { Drink } from "../context/AppContext";
+import type { Drink } from "../types";
 import { translations } from "../utils/translations";
 
 interface DrinkCardProps {

--- a/frontend/src/components/DrinkForm.tsx
+++ b/frontend/src/components/DrinkForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { X, Upload, Crop } from "lucide-react";
-import { useApp, Drink } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
@@ -34,7 +35,8 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
     recipe: "recipe" in drink ? drink.recipe || "" : "",
     baseSpirit: "base_spirit" in drink ? drink.base_spirit || "" : "",
     guestDescription: "guest_description" in drink ? drink.guest_description || "" : "",
-    showRecipeToGuests: "show_recipe_to_guests" in drink ? drink.show_recipe_to_guests || false : false,
+    showRecipeToGuests:
+      "show_recipe_to_guests" in drink ? drink.show_recipe_to_guests === 1 : false,
     categoryId: "category_id" in drink ? drink.category_id || "" : "",
     imageCropX: "image_crop_x" in drink ? drink.image_crop_x || 0 : 0,
     imageCropY: "image_crop_y" in drink ? drink.image_crop_y || 0 : 0,

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { useApp, Bar } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 import BarSelector from "./BarSelector";
 import BarCreator from "./BarCreator";
@@ -16,7 +17,7 @@ const LandingPage: React.FC = () => {
   const handleSelectBar = (bar: Bar) => {
     setSelectedBar(bar);
     setCurrentBar(bar);
-    setLanguage(bar.language as "en" | "da");
+    setLanguage(bar.language);
     setMode("login");
   };
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Eye, EyeOff, LogIn } from "lucide-react";
-import { useApp, Bar } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 
 interface LoginFormProps {

--- a/frontend/src/components/MenuTab.tsx
+++ b/frontend/src/components/MenuTab.tsx
@@ -51,7 +51,7 @@ const MenuTab: React.FC = () => {
 
       setDrinks((prev) =>
         prev.map((drink) =>
-          drink.id === id ? { ...drink, in_stock: !drink.in_stock } : drink
+          drink.id === id ? { ...drink, in_stock: drink.in_stock ? 0 : 1 } : drink
         )
       );
     } catch (err) {
@@ -187,7 +187,7 @@ const MenuTab: React.FC = () => {
                 {/* Recipe Preview */}
                 <div className="mb-4 line-clamp-2 prose max-w-none prose-p:text-gray-800 prose-li:text-gray-800 prose-strong:text-gray-900 prose-em:text-gray-700">
                   <LazyMarkdownViewer
-                    source={drink.recipe}
+                    source={drink.recipe ?? ""}
                     style={{ background: "none", padding: 0, margin: 0 }}
                   />
                 </div>

--- a/frontend/src/components/PastOrders.tsx
+++ b/frontend/src/components/PastOrders.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Eye, Package } from "lucide-react";
-import { Drink } from "../context/AppContext";
+import type { Drink } from "../types";
 import { TranslationKeys } from "../utils/translations";
 
 interface PastOrdersProps {

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -38,7 +38,7 @@ const QRRedirect: React.FC = () => {
         
         // Set the bar and language in context
         setCurrentBar(bar);
-        setLanguage(bar.language as "en" | "da");
+        setLanguage(bar.language);
         
         if (token) {
           // If there's a token, this is a QR code access - show guest name form
@@ -93,13 +93,9 @@ const QRRedirect: React.FC = () => {
       
       // The current bar should already be set from the earlier fetchBarInfo call,
       // but let's make sure it has the latest info
-      if (response.barId && response.barName && response.language) {
-        setCurrentBar({
-          id: response.barId,
-          name: response.barName,
-          language: response.language
-        });
-        setLanguage(response.language as "en" | "da");
+      if (response.bar) {
+        setCurrentBar(response.bar);
+        setLanguage(response.bar.language);
       }
 
       // Navigate to customer interface

--- a/frontend/src/components/RandomDrinkModal.tsx
+++ b/frontend/src/components/RandomDrinkModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Drink } from "../context/AppContext";
+import type { Drink } from "../types";
 import { translations } from "../utils/translations";
 
 interface RandomDrinkModalProps {

--- a/frontend/src/components/RecipeView.tsx
+++ b/frontend/src/components/RecipeView.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { X, Clock, Users, ChefHat } from "lucide-react";
-import { useApp, Drink } from "../context/AppContext";
+import { useApp } from "../context/AppContext";
+import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { LazyMarkdownViewer } from "./LazyMDEditor";
 
@@ -14,7 +15,9 @@ const RecipeView: React.FC<RecipeViewProps> = ({ drink, onClose }) => {
   const t = useTranslation(language);
 
   // Extract difficulty, prep time, and servings from recipe if present
-  const extractMetadata = (recipe: string) => {
+  const extractMetadata = (recipe: string | null) => {
+    if (!recipe) return { difficulty: null, prepTime: null, servings: null };
+
     const difficultyMatch = recipe.match(/difficulty:\s*(\w+)/i);
     const prepTimeMatch = recipe.match(
       /prep(?:\s+time)?:\s*(\d+(?:\s*-\s*\d+)?)\s*(?:min|minutes?)/i
@@ -151,7 +154,7 @@ const RecipeView: React.FC<RecipeViewProps> = ({ drink, onClose }) => {
           {/* Ensure the markdown container uses a readable color and prose styling */}
           <div className="prose prose-sm text-gray-800 max-w-none">
             <LazyMarkdownViewer
-              source={drink.recipe}
+              source={drink.recipe ?? ""}
               style={{
                 // Force readable text color for markdown output
                 ["--color-fg-default" as any]: "#222",

--- a/frontend/src/components/SettingsTab.tsx
+++ b/frontend/src/components/SettingsTab.tsx
@@ -12,7 +12,9 @@ const SettingsTab: React.FC = () => {
     apiCall,
   } = useApp();
   
-  const [skipApproval, setSkipApproval] = useState(currentBar?.skip_approval || false);
+  const [skipApproval, setSkipApproval] = useState(
+    currentBar?.skip_approval === 1
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   const handleSaveSettings = async () => {
@@ -31,7 +33,7 @@ const SettingsTab: React.FC = () => {
       
       // Update the current bar in the context
       setCurrentBar(updatedBar);
-      setSkipApproval(updatedBar.skip_approval || false);
+      setSkipApproval(updatedBar.skip_approval === 1);
       
       // Show success message (you could add a toast notification here)
       alert("Settings saved successfully!");

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -6,78 +6,48 @@ import React, {
   ReactNode,
 } from "react";
 
-// Types
-export interface Bar {
-  id: number;
+import type {
+  Analytics,
+  Bar,
+  Category,
+  Drink,
+  Language,
+  Order,
+  UserType,
+} from "../types";
+
+/** The bartender's tabs, in the order they appear. */
+export type Tab =
+  | "orders"
+  | "menu"
+  | "analytics"
+  | "categories"
+  | "settings";
+
+/** The two sign-in forms hold the same handful of fields throughout. */
+type BarForm = {
   name: string;
-  language: string;
-  skip_approval?: boolean;
-}
+  bartenderPassword: string;
+  guestPassword: string;
+  language: Language;
+};
 
-export interface Category {
-  id: number;
-  bar_id: number;
-  name: string;
-  created_at: string;
-}
-
-export interface Drink {
-  id: number;
-  bar_id: number;
-  title: string;
-  image_url?: string;
-  recipe: string;
-  in_stock: boolean;
-  created_at: string;
-  base_spirit?: string;
-  guest_description?: string;
-  show_recipe_to_guests?: boolean;
-  is_favourite?: boolean; // Added for favourite status
-  category_id?: number;
-  category_name?: string;
-  image_crop_x?: number;
-  image_crop_y?: number;
-  image_crop_zoom?: number;
-}
-
-export interface Order {
-  id: number;
-  bar_id: number;
-  customer_name: string;
-  drink_id: number;
-  drink_title: string;
-  drink_recipe?: string; // Recipe from drinks table, available for bartenders
-  status: "new" | "accepted" | "rejected" | "ready" | "processed";
-  created_at: string;
-  updated_at: string;
-}
-
-export interface Analytics {
-  totalOrders: number;
-  ordersToday: number;
-  popularDrinks: Array<{ drink_title: string; order_count: number }>;
-  peakHours: Array<{ hour: string; count: number }>;
-}
+type LoginForm = { password: string; name: string };
 
 interface AppContextType {
   // App state
-  userType: "bartender" | "guest" | null;
+  userType: UserType | null;
   currentBar: Bar | null;
   customerName: string;
-  language: "en" | "da";
+  language: Language;
 
   // Loading and error states
   loading: boolean;
   error: string | null;
 
   // Form states
-  barForm: {
-    name: string;
-    bartenderPassword: string;
-    guestPassword: string;
-    language: "en" | "da";
-  };
-  loginForm: { password: string; name: string };
+  barForm: BarForm;
+  loginForm: LoginForm;
 
   // Data states
   drinks: Drink[];
@@ -89,26 +59,17 @@ interface AppContextType {
   editingDrink: Drink | {} | null;
   viewingRecipe: Drink | null;
   showPassword: boolean;
-  currentTab: "orders" | "menu" | "analytics" | "categories" | "settings";
+  currentTab: Tab;
 
   // Setters
-  setUserType: (type: "bartender" | "guest" | null) => void;
+  setUserType: (type: UserType | null) => void;
   setCurrentBar: (bar: Bar | null) => void;
   setCustomerName: (name: string) => void;
-  setLanguage: (lang: "en" | "da") => void;
+  setLanguage: (lang: Language) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
-  setBarForm: React.Dispatch<
-    React.SetStateAction<{
-      name: string;
-      bartenderPassword: string;
-      guestPassword: string;
-      language: "en" | "da";
-    }>
-  >;
-  setLoginForm: React.Dispatch<
-    React.SetStateAction<{ password: string; name: string }>
-  >;
+  setBarForm: React.Dispatch<React.SetStateAction<BarForm>>;
+  setLoginForm: React.Dispatch<React.SetStateAction<LoginForm>>;
   setDrinks: React.Dispatch<React.SetStateAction<Drink[]>>;
   setOrders: React.Dispatch<React.SetStateAction<Order[]>>;
   setAnalytics: React.Dispatch<React.SetStateAction<Analytics | null>>;
@@ -116,7 +77,7 @@ interface AppContextType {
   setEditingDrink: (drink: Drink | {} | null) => void;
   setViewingRecipe: (drink: Drink | null) => void;
   setShowPassword: (show: boolean) => void;
-  setCurrentTab: (tab: "orders" | "menu" | "analytics" | "categories" | "settings") => void;
+  setCurrentTab: (tab: Tab) => void;
 
   // API helper
   apiCall: (endpoint: string, options?: RequestInit) => Promise<any>;
@@ -164,7 +125,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   };
 
   // App state with initial values from localStorage
-  const [userType, setUserTypeState] = useState<"bartender" | "guest" | null>(
+  const [userType, setUserTypeState] = useState<UserType | null>(
     () => loadFromStorage(STORAGE_KEYS.userType, null)
   );
 
@@ -176,16 +137,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     loadFromStorage(STORAGE_KEYS.customerName, "")
   );
 
-  const [language, setLanguageState] = useState<"en" | "da">(() =>
+  const [language, setLanguageState] = useState<Language>(() =>
     loadFromStorage(STORAGE_KEYS.language, "en")
   );
 
-  const [currentTab, setCurrentTabState] = useState<
-    "orders" | "menu" | "analytics" | "categories" | "settings"
-  >(() => loadFromStorage(STORAGE_KEYS.currentTab, "orders"));
+  const [currentTab, setCurrentTabState] = useState<Tab>(() =>
+    loadFromStorage(STORAGE_KEYS.currentTab, "orders")
+  );
 
   // Wrapper functions that save to storage
-  const setUserType = (type: "bartender" | "guest" | null) => {
+  const setUserType = (type: UserType | null) => {
     setUserTypeState(type);
     if (type === null) {
       localStorage.removeItem(STORAGE_KEYS.userType);
@@ -212,12 +173,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     }
   };
 
-  const setLanguage = (lang: "en" | "da") => {
+  const setLanguage = (lang: Language) => {
     setLanguageState(lang);
     saveToStorage(STORAGE_KEYS.language, lang);
   };
 
-  const setCurrentTab = (tab: "orders" | "menu" | "analytics" | "categories" | "settings") => {
+  const setCurrentTab = (tab: Tab) => {
     setCurrentTabState(tab);
     saveToStorage(STORAGE_KEYS.currentTab, tab);
   };
@@ -231,7 +192,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     name: "",
     bartenderPassword: "",
     guestPassword: "",
-    language: "en" as "en" | "da",
+    language: "en" as Language,
   });
   const [loginForm, setLoginForm] = useState({ password: "", name: "" });
 

--- a/frontend/src/context/LiveUpdatesContext.tsx
+++ b/frontend/src/context/LiveUpdatesContext.tsx
@@ -8,6 +8,7 @@ import React, {
   ReactNode,
 } from "react";
 import { useApp } from "./AppContext";
+import type { LiveUpdate } from "../types";
 
 interface LiveUpdatesContextType {
   isConnected: boolean;
@@ -94,7 +95,7 @@ export const LiveUpdatesProvider: React.FC<{ children: ReactNode }> = ({
 
     source.onmessage = (event) => {
       try {
-        const update = JSON.parse(event.data);
+        const update: LiveUpdate = JSON.parse(event.data);
         switch (update.type) {
           case "new_order":
           case "order_status_updated":

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,23 @@
+// What the pages get back from the API. The shapes live in shared/types.d.ts
+// next to the server, so changing one side without the other is a build error.
+//
+// A few things are re-named here to match how the pages talk about them.
+
+export type {
+  Bar,
+  Category,
+  Flag,
+  Language,
+  LiveUpdate,
+  OrderStatus,
+  UserType,
+} from "@shared/types";
+
+export type {
+  // The pages always list drinks with their category filled in, and with the
+  // favourite marked when the bar knows who is asking.
+  DrinkForGuest as Drink,
+  // Orders carry the recipe too, which only the bartender's pages show.
+  OrderForBartender as Order,
+  OrderAnalytics as Analytics,
+} from "@shared/types";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,6 +10,10 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
+
+    /* The API shapes, shared with the server. Types only, so nothing is
+       bundled and the build tool never has to resolve this. */
+    "paths": { "@shared/*": ["../shared/*"] },
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -88,6 +88,26 @@ export interface Favourite {
   created_at: string;
 }
 
+/** How busy the bar has been, for the reports tab. */
+export interface OrderAnalytics {
+  totalOrders: number;
+  ordersToday: number;
+  recentOrders: number;
+  popularDrinks: Array<{ drink_title: string; order_count: number }>;
+  peakHours: Array<{ hour: string; count: number }>;
+  statusDistribution: Array<{ status: OrderStatus; count: number }>;
+  averageOrdersPerDay: number;
+  /** The window the numbers cover, e.g. "30 days". */
+  period: string;
+}
+
+/** What is on the menu, for the reports tab. */
+export interface DrinkAnalytics {
+  popularDrinks: Array<{ drink_title: string; order_count: number }>;
+  totalDrinks: number;
+  inStockDrinks: number;
+}
+
 /** What the server pushes to browsers watching a bar. */
 export type LiveUpdate =
   | { type: "new_order"; order: Order; timestamp: string }


### PR DESCRIPTION
Second half of #27. The backend and `shared/types.d.ts` landed in #41; this has the frontend actually import them.

`AppContext` had its own hand-written copy of every API shape. They now come from `shared/types.d.ts` via a new `frontend/src/types.ts`, which is also where two are re-named to suit the pages (`DrinkForGuest` → `Drink`, `OrderForBartender` → `Order`).

## What the compiler found

Once the real shapes were in place, `tsc` reported eight errors. They were not type noise — each was a live defect.

**Settings quietly lost the auto-accept toggle.** Signing in replied with `barId`/`barName`/`language`, not the bar, so the pages assembled a partial one and dropped `skip_approval`. On the QR code path this was clearer still: `QRRedirect` fetched a complete bar, then overwrote it with the patched-up version a few lines later. Settings then read `undefined` and showed the toggle off however the bar was actually configured.

Sign-in and bar creation now reply with the whole bar. `LoginForm` never read the old fields at all and `/api/auth/verify` has no caller, so `QRRedirect` was the only thing to update.

**Opening a drink with no recipe threw.** `recipe` was typed as always present but is nullable, and `RecipeView` called `.match` on it.

**Flags were typed as booleans.** They arrive as `0`/`1` and worked only by being truthy. Flipping one in `MenuTab` produced a `boolean` the API would not have accepted.

## Also

- `OrderAnalytics` and `DrinkAnalytics` added — the reports were untyped, and `AppContext`'s guess at the shape was missing half the fields it is sent.
- Both analytics routes now use `satisfies`, so the reply and the type stay together.
- `backend/tests/auth.test.ts` covers the sign-in reply, including that password hashes never appear in it.
- The tab list and the two form shapes in `AppContext` were spelled out four times each; they are named types now.
- `COPY shared ../shared` added to the frontend Docker stage — the alias would not resolve there otherwise.

## Checked

64 tests pass, both linters and both typecheckers clean. Built the image and ran it against a copy of the production database: healthy, both migrations applied, 151 drinks on bar 2, photos serve, live updates stream, and the analytics injection still gets a 400.

Closes #27