### PR TITLE
Notice when an applied migration has been edited

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,14 @@ Add a dated `.sql` file to `backend/src/db/migrations/`. It is applied once on
 the next start and recorded by filename, oldest first.
 
 Never edit a migration that has already run — the change would be silently
-skipped on any database that has seen it. Add a new one instead.
+skipped on any database that has seen it. Add a new one instead. A fingerprint
+of each file is kept, so the app now refuses to start rather than run on with
+the two out of step. Comments and whitespace count as edits.
+
+A migration that mixes creating a table with adding a column should say
+`IF NOT EXISTS` on the create. Anything already applied by hand is caught up a
+statement at a time, and only statements that are harmless to run twice can be
+handled that way.
 
 Real installs have data in them. Anything that changes the schema should be
 tried against a copy of a real database first, not just an empty one.

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import fs from "fs";
 import type { Db } from "./queries.js";
 import path from "path";
@@ -13,10 +14,145 @@ const announce = (message: string): void => {
 };
 
 /**
+ * A fingerprint of a change file, so an edit to one already applied gets
+ * noticed. Line endings are levelled out first, or the same file checked out
+ * on another machine could look changed when it is not.
+ */
+function fingerprint(sql: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(sql.replace(/\r\n/g, "\n"))
+    .digest("hex");
+}
+
+/**
+ * The separate statements in a file, with comments dropped. Fine for the
+ * plain statements these files hold; it would need more care for anything
+ * with a semicolon inside it, such as a trigger.
+ */
+function statementsIn(sql: string): string[] {
+  return sql
+    .replace(/--[^\n]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split(";")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+const ADDS_A_COLUMN = /^ALTER\s+TABLE\s+\S+\s+ADD\s+(COLUMN\s+)?/i;
+const ONLY_IF_MISSING = /\bIF\s+NOT\s+EXISTS\b/i;
+
+/**
+ * True when every statement in the file is harmless to run a second time:
+ * either it adds a column, which can be skipped if the column is already
+ * there, or it says "if not exists" and does nothing.
+ */
+function safeToRunAgain(sql: string): boolean {
+  return statementsIn(sql).every(
+    (statement) =>
+      ADDS_A_COLUMN.test(statement) || ONLY_IF_MISSING.test(statement)
+  );
+}
+
+/**
+ * Runs the file a statement at a time, stepping over columns the database
+ * already has. This is how a database that had changes applied by hand,
+ * before anything kept a record, gets caught up.
+ */
+function runSkippingExistingColumns(db: Db, sql: string): void {
+  for (const statement of statementsIn(sql)) {
+    try {
+      db.exec(statement);
+    } catch (error) {
+      const isDuplicate =
+        error instanceof Error && /duplicate column name/i.test(error.message);
+
+      if (isDuplicate && ADDS_A_COLUMN.test(statement)) continue;
+      throw error;
+    }
+  }
+}
+
+/** Older databases recorded a name and nothing else. */
+function addChecksumColumn(db: Db): void {
+  const columns = db.prepare("PRAGMA table_info(migrations)").all() as {
+    name: string;
+  }[];
+
+  if (!columns.some((column) => column.name === "checksum")) {
+    db.exec("ALTER TABLE migrations ADD COLUMN checksum TEXT");
+  }
+}
+
+/**
+ * Checks what was applied against what is on disk now. Rows from before
+ * fingerprints were kept have none, and are left alone.
+ */
+function checkNothingChanged(db: Db, migrationsDir: string): void {
+  const recorded = db
+    .prepare("SELECT name, checksum FROM migrations WHERE checksum IS NOT NULL")
+    .all() as { name: string; checksum: string }[];
+
+  const edited: string[] = [];
+
+  for (const { name, checksum } of recorded) {
+    const file = path.join(migrationsDir, name);
+
+    // A file that has been removed cannot be compared. Worth saying, but not
+    // worth refusing to start over.
+    if (!fs.existsSync(file)) {
+      announce(`Migration ${name} was applied but is no longer in the folder.`);
+      continue;
+    }
+
+    if (fingerprint(fs.readFileSync(file, "utf8")) !== checksum) {
+      edited.push(name);
+    }
+  }
+
+  if (edited.length > 0) {
+    throw new Error(
+      `These migrations have already been applied to the database and have ` +
+        `since been edited: ${edited.join(", ")}. An edit to a file that has ` +
+        `already run is never applied, so the database and the code no longer ` +
+        `match. Put the file back as it was and add a new one instead.`
+    );
+  }
+}
+
+/**
+ * Fills in fingerprints for migrations that were applied before any were
+ * kept, taking the files as they stand today. Nothing can be proved about
+ * those either way, but once they are stamped a later edit does get noticed.
+ */
+function stampOlderRows(db: Db, migrationsDir: string): void {
+  const unstamped = db
+    .prepare("SELECT name FROM migrations WHERE checksum IS NULL")
+    .all() as { name: string }[];
+
+  const stamp = db.prepare("UPDATE migrations SET checksum = ? WHERE name = ?");
+
+  for (const { name } of unstamped) {
+    const file = path.join(migrationsDir, name);
+    if (!fs.existsSync(file)) continue;
+
+    stamp.run(fingerprint(fs.readFileSync(file, "utf8")), name);
+  }
+}
+
+export interface MigrateOptions {
+  /** Where the .sql files live. Tests point this at a folder of their own. */
+  migrationsDir?: string;
+}
+
+/**
  * Brings the database up to date. Runs on every start; does nothing if there
  * is nothing new to apply.
  */
-export function runMigrations(db: Db): string[] {
+export function runMigrations(
+  db: Db,
+  { migrationsDir = MIGRATIONS_DIR }: MigrateOptions = {}
+): string[] {
   // Creates the tables only if they are missing.
   db.exec(fs.readFileSync(SCHEMA_FILE, "utf8"));
 
@@ -24,18 +160,26 @@ export function runMigrations(db: Db): string[] {
     CREATE TABLE IF NOT EXISTS migrations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT UNIQUE,
+      checksum TEXT,
       applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
   `);
 
-  if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+  addChecksumColumn(db);
+
+  if (!fs.existsSync(migrationsDir)) return [];
+
+  checkNothingChanged(db, migrationsDir);
+  stampOlderRows(db, migrationsDir);
 
   const isApplied = db.prepare("SELECT 1 FROM migrations WHERE name = ?");
-  const markApplied = db.prepare("INSERT INTO migrations (name) VALUES (?)");
+  const markApplied = db.prepare(
+    "INSERT INTO migrations (name, checksum) VALUES (?, ?)"
+  );
 
   // Sorted so the date-named files apply oldest first.
   const files = fs
-    .readdirSync(MIGRATIONS_DIR)
+    .readdirSync(migrationsDir)
     .filter((f) => f.endsWith(".sql"))
     .sort();
 
@@ -44,34 +188,41 @@ export function runMigrations(db: Db): string[] {
   for (const file of files) {
     if (isApplied.get(file)) continue;
 
-    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8");
+    const sql = fs.readFileSync(path.join(migrationsDir, file), "utf8");
+    const checksum = fingerprint(sql);
 
     try {
       // All or nothing, so a failure leaves no half-applied change.
       db.transaction(() => {
         db.exec(sql);
-        markApplied.run(file);
+        markApplied.run(file, checksum);
       })();
+
+      announce(`Applied migration: ${file}`);
     } catch (error) {
-      // An older database may already have this change. Record it instead of
-      // failing to start.
-      if (error instanceof Error && /duplicate column name/i.test(error.message)) {
-        announce(
-          `Migration ${file} was already present in the schema; recording it as applied.`
+      const isDuplicate =
+        error instanceof Error && /duplicate column name/i.test(error.message);
+
+      // An older database may already have part of this. Catching it up beats
+      // refusing to start, but only where every statement is safe to run
+      // again — otherwise a table the file also creates would be skipped.
+      if (!isDuplicate || !safeToRunAgain(sql)) {
+        throw new Error(
+          `Migration ${file} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          { cause: error }
         );
-        markApplied.run(file);
-        applied.push(file);
-        continue;
       }
-      throw new Error(
-        `Migration ${file} failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        { cause: error }
-      );
+
+      db.transaction(() => {
+        runSkippingExistingColumns(db, sql);
+        markApplied.run(file, checksum);
+      })();
+
+      announce(`Migration ${file} was partly there already; applied the rest.`);
     }
 
-    announce(`Applied migration: ${file}`);
     applied.push(file);
   }
 

--- a/backend/tests/migrate.test.ts
+++ b/backend/tests/migrate.test.ts
@@ -8,6 +8,7 @@ import type { Db } from "../src/db/queries.js";
 import {
   makeEmptyDatabase,
   makeTestDatabase,
+  makeTempDir,
   cleanUpTempDirs,
 } from "./helpers.js";
 
@@ -117,5 +118,148 @@ describe("migrations", () => {
     expect(() => db.exec("ALTER TABLE drinks ADD COLUMN title TEXT")).toThrow();
 
     expect(appliedNames(db)).toEqual(before);
+  });
+});
+
+// A file that has already run is never run again, so editing one leaves the
+// database and the code saying different things with nothing to show for it.
+describe("noticing an edited migration", () => {
+  /** A folder holding just the migrations a test writes into it. */
+  const migrationFolder = (files: Record<string, string>): string => {
+    const dir = makeTempDir("home-bar-migrations-");
+    for (const [name, sql] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), sql);
+    }
+    return dir;
+  };
+
+  const checksums = (db: Db): Record<string, string | null> =>
+    Object.fromEntries(
+      (
+        db.prepare("SELECT name, checksum FROM migrations").all() as {
+          name: string;
+          checksum: string | null;
+        }[]
+      ).map((r) => [r.name, r.checksum])
+    );
+
+  it("records a fingerprint with every migration it applies", () => {
+    const db = makeEmptyDatabase();
+
+    runMigrations(db);
+
+    const recorded = checksums(db);
+    expect(Object.keys(recorded).sort()).toEqual(allMigrations);
+    for (const name of allMigrations) {
+      expect(recorded[name]).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it("refuses to start once an applied migration has been edited", () => {
+    const db = makeEmptyDatabase();
+    const dir = migrationFolder({
+      "2099-01-01-add-thing.sql": "ALTER TABLE drinks ADD COLUMN thing TEXT;",
+    });
+
+    runMigrations(db, { migrationsDir: dir });
+
+    fs.writeFileSync(
+      path.join(dir, "2099-01-01-add-thing.sql"),
+      "ALTER TABLE drinks ADD COLUMN something_else TEXT;"
+    );
+
+    expect(() => runMigrations(db, { migrationsDir: dir })).toThrow(
+      /2099-01-01-add-thing\.sql/
+    );
+  });
+
+  it("accepts rows recorded before fingerprints were kept, then watches them", () => {
+    const db = makeEmptyDatabase();
+    const file = "2099-01-01-add-thing.sql";
+    const dir = migrationFolder({
+      [file]: "ALTER TABLE drinks ADD COLUMN thing TEXT;",
+    });
+
+    // How an existing install looks: applied, with nothing to compare against.
+    runMigrations(db, { migrationsDir: dir });
+    db.prepare("UPDATE migrations SET checksum = NULL").run();
+
+    fs.writeFileSync(
+      path.join(dir, file),
+      "ALTER TABLE drinks ADD COLUMN something_else TEXT;"
+    );
+
+    // Starts anyway, and takes the file as it stands as the one to keep to.
+    expect(() => runMigrations(db, { migrationsDir: dir })).not.toThrow();
+    expect(checksums(db)[file]).toMatch(/^[0-9a-f]{64}$/);
+
+    // From here on an edit is caught like any other.
+    fs.writeFileSync(path.join(dir, file), "ALTER TABLE drinks ADD COLUMN third TEXT;");
+
+    expect(() => runMigrations(db, { migrationsDir: dir })).toThrow(
+      new RegExp(file.replace(/\./g, "\\."))
+    );
+  });
+
+  it("carries on when an applied migration file has been removed", () => {
+    const db = makeEmptyDatabase();
+    const dir = migrationFolder({
+      "2099-01-01-add-thing.sql": "ALTER TABLE drinks ADD COLUMN thing TEXT;",
+    });
+
+    runMigrations(db, { migrationsDir: dir });
+    fs.rmSync(path.join(dir, "2099-01-01-add-thing.sql"));
+
+    expect(() => runMigrations(db, { migrationsDir: dir })).not.toThrow();
+    expect(appliedNames(db)).toEqual(["2099-01-01-add-thing.sql"]);
+  });
+});
+
+// The old recovery wrote the whole file off as done the moment one column was
+// already there, so anything else in the same file never ran.
+describe("catching up a database that was changed by hand", () => {
+  const write = (dir: string, name: string, sql: string): void =>
+    fs.writeFileSync(path.join(dir, name), sql);
+
+  it("applies the rest of a migration whose column already exists", () => {
+    const db = makeEmptyDatabase();
+    const dir = makeTempDir("home-bar-migrations-");
+
+    write(
+      dir,
+      "2099-01-01-mixed.sql",
+      `CREATE TABLE IF NOT EXISTS widgets (id INTEGER PRIMARY KEY);
+       ALTER TABLE drinks ADD COLUMN widget_id INTEGER;`
+    );
+
+    // The column is there but the table is not — someone applied half of it.
+    runMigrations(db);
+    db.exec("ALTER TABLE drinks ADD COLUMN widget_id INTEGER");
+
+    expect(runMigrations(db, { migrationsDir: dir })).toEqual([
+      "2099-01-01-mixed.sql",
+    ]);
+    expect(columnsOf(db, "widgets")).toEqual(["id"]);
+  });
+
+  it("stops rather than skip a migration that cannot be run again safely", () => {
+    const db = makeEmptyDatabase();
+    const dir = makeTempDir("home-bar-migrations-");
+
+    // No "if not exists", so running this a second time is not harmless.
+    write(
+      dir,
+      "2099-01-02-unsafe.sql",
+      `CREATE TABLE gadgets (id INTEGER PRIMARY KEY);
+       ALTER TABLE drinks ADD COLUMN gadget_id INTEGER;`
+    );
+
+    runMigrations(db);
+    db.exec("ALTER TABLE drinks ADD COLUMN gadget_id INTEGER");
+
+    expect(() => runMigrations(db, { migrationsDir: dir })).toThrow(
+      /2099-01-02-unsafe\.sql/
+    );
+    expect(appliedNames(db)).not.toContain("2099-01-02-unsafe.sql");
   });
 });


### PR DESCRIPTION
Closes #28.

Migrations were tracked by filename only, so editing one that had already run did nothing — the database and the repo drift apart silently. A sha256 of each file is now stored beside the name, and a start that finds a recorded file changed stops with a message naming it.

```
Error: These migrations have already been applied to the database and have since
been edited: 2025-09-10-add-categories.sql. An edit to a file that has already run
is never applied, so the database and the code no longer match. Put the file back
as it was and add a new one instead.
```

Line endings are levelled before hashing, so the same file checked out on another machine does not read as edited.

## Existing databases

The issue suggested backfilling as `NULL` and treating `NULL` as "unverified, accept". I did that, and then went one step further: the first start stamps the unfingerprinted rows with the files as they stand.

Nothing can be proved about those six either way — if one had already been edited, we have no way to know. But leaving them `NULL` means they stay unverifiable forever, and the protection would only ever apply to migrations added from today. Stamping costs nothing and makes a future edit to any of them detectable. Say if you would rather it stayed strictly `NULL`.

## The recovery path

The issue flagged this as unreachable-but-worth-guarding, and it turned out to be the more interesting half.

`duplicate column name` was treated as "this whole file is already applied" — but the guard rolls the transaction back **before** recording it. So a migration that both creates a table and adds a column would skip the create if only the column existed. `2025-09-10-add-categories.sql` is exactly that shape: it creates `categories`, adds `drinks.category_id`, and creates two indexes.

It now applies such a file a statement at a time, stepping over columns that already exist, and refuses outright unless every statement is safe to run twice — each one either adds a column or says `IF NOT EXISTS`. A file that would be damaged by a partial re-run stops the start instead of being quietly written off.

Two tests cover this; both fail against the old behaviour.

## Checked

70 tests pass, lint and typecheck clean.

Against a copy of the production database in the built image:
- `migrations` gained `checksum`; all six existing rows stamped
- 155 drinks, 2 bars, 36 orders intact
- restarted — nothing re-applied, still healthy
- edited an applied migration inside the container and confirmed it refuses to start with the message above

`runMigrations()` now takes the folder to read, so tests can point at their own.