### PR TITLE
Break up the oversized components

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,10 @@ const AppContent: React.FC = () => {
   // Drink form modal
   if (editingDrink !== null) {
     return (
-      <DrinkForm drink={editingDrink} onClose={() => setEditingDrink(null)} />
+      <DrinkForm
+        drink={editingDrink === "new" ? null : editingDrink}
+        onClose={() => setEditingDrink(null)}
+      />
     );
   }
 

--- a/frontend/src/components/AnalyticsTab.tsx
+++ b/frontend/src/components/AnalyticsTab.tsx
@@ -1,29 +1,79 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { BarChart3, TrendingUp, Coffee, Clock, Star } from "lucide-react";
 import { useApp } from "../context/AppContext";
+import type { OrderStatus } from "../types";
 import { useTranslation } from "../utils/translations";
+import StatCard from "./analytics/StatCard";
+import StatList from "./analytics/StatList";
+import RankedBars from "./analytics/RankedBars";
+
+/** The steps an order goes through, and how each is drawn. */
+const STATUS_TILES: Array<{
+  status: OrderStatus;
+  label: string;
+  dot: string;
+  tint: string;
+  text: string;
+}> = [
+  {
+    status: "new",
+    label: "New",
+    dot: "bg-yellow-500",
+    tint: "bg-yellow-50",
+    text: "text-yellow-700",
+  },
+  {
+    status: "accepted",
+    label: "Accepted",
+    dot: "bg-blue-500",
+    tint: "bg-blue-50",
+    text: "text-blue-700",
+  },
+  {
+    status: "rejected",
+    label: "Rejected",
+    dot: "bg-red-500",
+    tint: "bg-red-50",
+    text: "text-red-700",
+  },
+  {
+    status: "ready",
+    label: "Ready",
+    dot: "bg-green-500",
+    tint: "bg-green-50",
+    text: "text-green-700",
+  },
+  {
+    status: "processed",
+    label: "Completed",
+    dot: "bg-gray-500",
+    tint: "bg-gray-50",
+    text: "text-gray-700",
+  },
+];
+
+const isToday = (when: string): boolean =>
+  new Date(when).toDateString() === new Date().toDateString();
 
 const AnalyticsTab: React.FC = () => {
   const { currentBar, language, analytics, orders, setAnalytics, apiCall } =
     useApp();
 
   const t = useTranslation(language);
+  const barId = currentBar?.id;
 
-  const fetchAnalytics = async () => {
-    if (!currentBar) return;
+  const fetchAnalytics = useCallback(async () => {
+    if (!barId) return;
     try {
-      const data = await apiCall(`/orders/bar/${currentBar.id}/analytics`);
-      setAnalytics(data);
+      setAnalytics(await apiCall(`/orders/bar/${barId}/analytics`));
     } catch (err) {
-      console.error("Error fetching analytics:", err);
+      console.error("Could not load the reports:", err);
     }
-  };
+  }, [barId, apiCall, setAnalytics]);
 
   useEffect(() => {
-    if (currentBar) {
-      fetchAnalytics();
-    }
-  }, [currentBar]);
+    fetchAnalytics();
+  }, [fetchAnalytics]);
 
   if (!analytics) {
     return (
@@ -37,326 +87,121 @@ const AnalyticsTab: React.FC = () => {
     );
   }
 
-  const getMaxCount = (
-    data: Array<{ count?: number; order_count?: number }>
-  ) => {
-    return Math.max(...data.map((item) => item.count || item.order_count || 0));
-  };
+  const topDrink = analytics.popularDrinks[0]?.drink_title;
+  const completedToday = orders.filter(
+    (order) => order.status === "processed" && isToday(order.updated_at)
+  ).length;
 
   return (
     <div className="space-y-6">
-      {/* Overview Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center">
-            <div className="p-3 bg-blue-100 rounded-lg">
-              <BarChart3 className="w-6 h-6 text-blue-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">
-                {t("totalOrders")}
-              </p>
-              <p className="text-2xl font-bold text-gray-900">
-                {analytics.totalOrders}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center">
-            <div className="p-3 bg-green-100 rounded-lg">
-              <TrendingUp className="w-6 h-6 text-green-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">
-                {t("ordersToday")}
-              </p>
-              <p className="text-2xl font-bold text-gray-900">
-                {analytics.ordersToday}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center">
-            <div className="p-3 bg-purple-100 rounded-lg">
-              <Coffee className="w-6 h-6 text-purple-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Top Drink</p>
-              <p className="text-lg font-bold text-gray-900 truncate">
-                {analytics.popularDrinks[0]?.drink_title || "N/A"}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center">
-            <div className="p-3 bg-yellow-100 rounded-lg">
-              <Clock className="w-6 h-6 text-yellow-600" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Peak Hour</p>
-              <p className="text-lg font-bold text-gray-900">
-                {analytics.peakHours[0]?.hour || "N/A"}
-              </p>
-            </div>
-          </div>
-        </div>
+        <StatCard
+          icon={<BarChart3 className="w-6 h-6 text-blue-600" />}
+          tint="bg-blue-100"
+          label={t("totalOrders")}
+          value={analytics.totalOrders}
+        />
+        <StatCard
+          icon={<TrendingUp className="w-6 h-6 text-green-600" />}
+          tint="bg-green-100"
+          label={t("ordersToday")}
+          value={analytics.ordersToday}
+        />
+        <StatCard
+          icon={<Coffee className="w-6 h-6 text-purple-600" />}
+          tint="bg-purple-100"
+          label="Top Drink"
+          value={topDrink || "N/A"}
+          small
+        />
+        <StatCard
+          icon={<Clock className="w-6 h-6 text-yellow-600" />}
+          tint="bg-yellow-100"
+          label="Peak Hour"
+          value={analytics.peakHours[0]?.hour || "N/A"}
+          small
+        />
       </div>
 
-      {/* Charts Section */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Popular Drinks */}
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center mb-6">
-            <Star className="w-5 h-5 text-yellow-500 mr-2" />
-            <h3 className="text-lg font-semibold text-gray-800">
-              {t("popularDrinks")}
-            </h3>
-          </div>
+        <RankedBars
+          icon={<Star className="w-5 h-5 text-yellow-500 mr-2" />}
+          heading={t("popularDrinks")}
+          rows={analytics.popularDrinks.map((d) => ({
+            label: d.drink_title,
+            value: d.order_count,
+          }))}
+          emptyIcon={<Coffee className="w-12 h-12 mx-auto mb-3 opacity-50" />}
+          emptyMessage="No order data yet"
+          barColour="bg-blue-600"
+        />
 
-          {analytics.popularDrinks.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              <Coffee className="w-12 h-12 mx-auto mb-3 opacity-50" />
-              <p>No order data yet</p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {analytics.popularDrinks.slice(0, 5).map((item, index) => {
-                const maxCount = getMaxCount(analytics.popularDrinks);
-                const percentage =
-                  maxCount > 0 ? (item.order_count / maxCount) * 100 : 0;
-
-                return (
-                  <div
-                    key={item.drink_title}
-                    className="flex items-center justify-between"
-                  >
-                    <div className="flex items-center space-x-3 flex-1">
-                      <span className="text-sm font-medium text-gray-500 w-6">
-                        #{index + 1}
-                      </span>
-                      <span className="font-medium text-gray-800 truncate">
-                        {item.drink_title}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-3 ml-4">
-                      <div className="w-24 bg-gray-200 rounded-full h-2">
-                        <div
-                          className="bg-blue-600 h-2 rounded-full transition-all duration-500"
-                          style={{ width: `${percentage}%` }}
-                        />
-                      </div>
-                      <span className="text-sm text-gray-600 w-8 text-right">
-                        {item.order_count}
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-
-        {/* Peak Hours */}
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <div className="flex items-center mb-6">
-            <Clock className="w-5 h-5 text-green-500 mr-2" />
-            <h3 className="text-lg font-semibold text-gray-800">
-              {t("peakHours")}
-            </h3>
-          </div>
-
-          {analytics.peakHours.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
-              <Clock className="w-12 h-12 mx-auto mb-3 opacity-50" />
-              <p>No peak hour data yet</p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {analytics.peakHours.slice(0, 5).map((item, index) => {
-                const maxCount = getMaxCount(analytics.peakHours);
-                const percentage =
-                  maxCount > 0 ? (item.count / maxCount) * 100 : 0;
-
-                return (
-                  <div
-                    key={item.hour}
-                    className="flex items-center justify-between"
-                  >
-                    <div className="flex items-center space-x-3">
-                      <span className="text-sm font-medium text-gray-500 w-6">
-                        #{index + 1}
-                      </span>
-                      <span className="font-medium text-gray-800">
-                        {item.hour}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-3">
-                      <div className="w-24 bg-gray-200 rounded-full h-2">
-                        <div
-                          className="bg-green-600 h-2 rounded-full transition-all duration-500"
-                          style={{ width: `${percentage}%` }}
-                        />
-                      </div>
-                      <span className="text-sm text-gray-600 w-8 text-right">
-                        {item.count}
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
+        <RankedBars
+          icon={<Clock className="w-5 h-5 text-green-500 mr-2" />}
+          heading={t("peakHours")}
+          rows={analytics.peakHours.map((h) => ({
+            label: h.hour,
+            value: h.count,
+          }))}
+          emptyIcon={<Clock className="w-12 h-12 mx-auto mb-3 opacity-50" />}
+          emptyMessage="No peak hour data yet"
+          barColour="bg-green-600"
+        />
       </div>
 
-      {/* Order Status Distribution */}
       <div className="bg-white rounded-lg shadow-sm border p-6">
         <h3 className="text-lg font-semibold text-gray-800 mb-6">
           Order Status Distribution
         </h3>
 
         <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          {[
-            {
-              status: "new",
-              label: "New",
-              color: "bg-yellow-500",
-              bgColor: "bg-yellow-50",
-              textColor: "text-yellow-700",
-            },
-            {
-              status: "accepted",
-              label: "Accepted",
-              color: "bg-blue-500",
-              bgColor: "bg-blue-50",
-              textColor: "text-blue-700",
-            },
-            {
-              status: "rejected",
-              label: "Rejected",
-              color: "bg-red-500",
-              bgColor: "bg-red-50",
-              textColor: "text-red-700",
-            },
-            {
-              status: "ready",
-              label: "Ready",
-              color: "bg-green-500",
-              bgColor: "bg-green-50",
-              textColor: "text-green-700",
-            },
-            {
-              status: "processed",
-              label: "Completed",
-              color: "bg-gray-500",
-              bgColor: "bg-gray-50",
-              textColor: "text-gray-700",
-            },
-          ].map(({ status, label, color, bgColor, textColor }) => {
-            const count = orders.filter(
-              (order) => order.status === status
-            ).length;
-            return (
-              <div
-                key={status}
-                className={`${bgColor} rounded-lg p-4 text-center`}
-              >
-                <div className={`w-4 h-4 ${color} rounded-full mx-auto mb-2`} />
-                <p className={`text-sm font-medium ${textColor}`}>{label}</p>
-                <p className="text-2xl font-bold text-gray-900">{count}</p>
-              </div>
-            );
-          })}
+          {STATUS_TILES.map(({ status, label, dot, tint, text }) => (
+            <div key={status} className={`${tint} rounded-lg p-4 text-center`}>
+              <div className={`w-4 h-4 ${dot} rounded-full mx-auto mb-2`} />
+              <p className={`text-sm font-medium ${text}`}>{label}</p>
+              <p className="text-2xl font-bold text-gray-900">
+                {orders.filter((order) => order.status === status).length}
+              </p>
+            </div>
+          ))}
         </div>
       </div>
 
-      {/* Recent Activity Summary */}
       <div className="bg-white rounded-lg shadow-sm border p-6">
         <h3 className="text-lg font-semibold text-gray-800 mb-6">
           Recent Activity Summary
         </h3>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <h4 className="font-medium text-gray-700 mb-3">
-              Today's Performance
-            </h4>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">Orders placed</span>
-                <span className="text-sm font-medium">
-                  {analytics.ordersToday}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">Orders completed</span>
-                <span className="text-sm font-medium">
-                  {
-                    orders.filter(
-                      (o) =>
-                        o.status === "processed" &&
-                        new Date(o.updated_at).toDateString() ===
-                          new Date().toDateString()
-                    ).length
-                  }
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">Completion rate</span>
-                <span className="text-sm font-medium">
-                  {analytics.ordersToday > 0
-                    ? Math.round(
-                        (orders.filter(
-                          (o) =>
-                            o.status === "processed" &&
-                            new Date(o.updated_at).toDateString() ===
-                              new Date().toDateString()
-                        ).length /
-                          analytics.ordersToday) *
-                          100
-                      )
-                    : 0}
-                  %
-                </span>
-              </div>
-            </div>
-          </div>
+          <StatList
+            heading="Today's Performance"
+            rows={[
+              { label: "Orders placed", value: analytics.ordersToday },
+              { label: "Orders completed", value: completedToday },
+              {
+                label: "Completion rate",
+                value: `${
+                  analytics.ordersToday > 0
+                    ? Math.round((completedToday / analytics.ordersToday) * 100)
+                    : 0
+                }%`,
+              },
+            ]}
+          />
 
-          <div>
-            <h4 className="font-medium text-gray-700 mb-3">All Time Stats</h4>
-            <div className="space-y-2">
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">Total orders</span>
-                <span className="text-sm font-medium">
-                  {analytics.totalOrders}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">
-                  Avg orders per day
-                </span>
-                <span className="text-sm font-medium">
-                  {analytics.totalOrders > 0
-                    ? Math.round(analytics.totalOrders / 7)
-                    : 0}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-sm text-gray-600">
-                  Most popular drink
-                </span>
-                <span className="text-sm font-medium truncate max-w-32">
-                  {analytics.popularDrinks[0]?.drink_title || "None"}
-                </span>
-              </div>
-            </div>
-          </div>
+          <StatList
+            heading="All Time Stats"
+            rows={[
+              { label: "Total orders", value: analytics.totalOrders },
+              {
+                // The server works this out over the report's window, so the
+                // label says which window rather than implying all time.
+                label: `Avg orders per day (last ${analytics.period})`,
+                value: analytics.averageOrdersPerDay,
+              },
+              { label: "Most popular drink", value: topDrink || "None" },
+            ]}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/BartenderDashboard.tsx
+++ b/frontend/src/components/BartenderDashboard.tsx
@@ -221,7 +221,7 @@ const BartenderDashboard: React.FC = () => {
       {currentTab === "menu" && (
         <div className="fixed bottom-6 right-6 lg:hidden">
           <button
-            onClick={() => setEditingDrink({})}
+            onClick={() => setEditingDrink("new")}
             className="bg-blue-600 text-white p-4 rounded-full shadow-lg hover:bg-blue-700 transition-colors"
           >
             <Plus className="w-6 h-6" />

--- a/frontend/src/components/CustomerInterface.tsx
+++ b/frontend/src/components/CustomerInterface.tsx
@@ -1,14 +1,21 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Clock, CheckCircle, XCircle, Coffee, Check } from "lucide-react";
+import { Coffee } from "lucide-react";
 import { useApp } from "../context/AppContext";
 import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { useSessionManager } from "../hooks/useSessionManager";
+import { useGuestMenu } from "../hooks/useGuestMenu";
 import { useLiveUpdates } from "../context/LiveUpdatesContext";
 import { ConnectionLost } from "./ConnectionLost";
-import DrinkCard from "./DrinkCard";
 import OrderStatusCard from "./OrderStatusCard";
+import RandomDrinkModal from "./RandomDrinkModal";
+import DrinkGrid from "./customer/DrinkGrid";
+import OrderPlacedModal from "./customer/OrderPlacedModal";
+import { MenuFilterSelect, MenuSidebar } from "./customer/MenuFilters";
+
+/** Statuses that mean a guest still has a drink on the go. */
+const IN_PROGRESS = ["new", "accepted", "ready"];
 
 const CustomerInterface: React.FC = () => {
   const {
@@ -16,10 +23,7 @@ const CustomerInterface: React.FC = () => {
     customerName,
     language,
     loading,
-    drinks,
     orders,
-    setDrinks,
-    setOrders,
     setViewingRecipe,
     setLoading,
     setError,
@@ -30,145 +34,41 @@ const CustomerInterface: React.FC = () => {
   const { clearSession } = useSessionManager();
   const navigate = useNavigate();
   const { connectionError, reconnect } = useLiveUpdates();
+
+  const menu = useGuestMenu();
+
   const [noticeDismissed, setNoticeDismissed] = useState(false);
+  const [showOrderPlaced, setShowOrderPlaced] = useState(false);
+  const [randomDrink, setRandomDrink] = useState<Drink | null>(null);
 
   // Show the notice again if updates drop out a second time.
   useEffect(() => {
     if (!connectionError) setNoticeDismissed(false);
   }, [connectionError]);
 
-  // Modal state for order placed
-  const [showOrderPlacedModal, setShowOrderPlacedModal] = useState(false);
-  // Restore state for random drink modal
-  const [randomDrink, setRandomDrink] = useState<Drink | null>(null);
-  const [showRandomModal, setShowRandomModal] = useState(false);
-  
-  // Favourites state
-  const [favouriteDrinks, setFavouriteDrinks] = useState<Drink[]>([]);
-
-  // Filter state
-  const [activeFilter, setActiveFilter] = useState<{
-    type: "all" | "category" | "spirit";
-    value?: string;
-  }>({ type: "all" });
-
-  // Tab state for mobile - no longer needed since we navigate to separate page
-  // const [mobileTab, setMobileTab] = useState<"menu" | "history">("menu");
-
-  // Data fetching
-  const fetchDrinks = async () => {
-    if (!currentBar || !customerName) return;
-    try {
-      // Use guest endpoint with customer name to get drinks with favourite status
-      const data = await apiCall(`/drinks/bar/${currentBar.id}/guest/${encodeURIComponent(customerName)}`);
-      setDrinks(data);
-    } catch (err) {
-      console.error("Error fetching drinks:", err);
-    }
-  };
-
-  const fetchFavourites = async () => {
-    if (!currentBar || !customerName) return;
-    try {
-      const data = await apiCall(`/drinks/bar/${currentBar.id}/favourites/${encodeURIComponent(customerName)}`);
-      // Sort favourites alphabetically
-      data.sort((a: Drink, b: Drink) => a.title.localeCompare(b.title));
-      setFavouriteDrinks(data);
-    } catch (err) {
-      console.error("Error fetching favourites:", err);
-    }
-  };
-
-  const fetchOrders = async () => {
-    if (!currentBar) return;
-    try {
-      const data = await apiCall(`/orders/bar/${currentBar.id}`);
-      setOrders(data);
-    } catch (err) {
-      console.error("Error fetching orders:", err);
-    }
-  };
-
+  // Escape closes the surprise-me pick.
   useEffect(() => {
-    if (currentBar && customerName) {
-      fetchDrinks();
-      fetchFavourites();
-      fetchOrders();
-    }
-  }, [currentBar, customerName]);
+    if (!randomDrink) return;
 
-  // Get customer's current order
-  const customerOrder = orders.find(
+    const close = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setRandomDrink(null);
+    };
+
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [randomDrink]);
+
+  const currentOrder = orders.find(
     (order) =>
-      order.customer_name === customerName &&
-      ["new", "accepted", "ready"].includes(order.status)
+      order.customer_name === customerName && IN_PROGRESS.includes(order.status)
   );
 
-  // Group available drinks by base spirit
-  const groupedDrinks: { [spirit: string]: typeof drinks } = {};
-  drinks.forEach((drink) => {
-    if (drink.in_stock) {
-      const spirit = drink.base_spirit || "Other";
-      if (!groupedDrinks[spirit]) groupedDrinks[spirit] = [];
-      groupedDrinks[spirit].push(drink);
-    }
-  });
-  
-  // Sort drinks within each spirit group alphabetically
-  Object.keys(groupedDrinks).forEach((spirit) => {
-    groupedDrinks[spirit].sort((a, b) => a.title.localeCompare(b.title));
-  });
-  
-  // Group available drinks by category
-  const groupedByCategory: { [category: string]: typeof drinks } = {};
-  drinks.forEach((drink) => {
-    if (drink.in_stock) {
-      const category = drink.category_name || "Uncategorized";
-      if (!groupedByCategory[category]) groupedByCategory[category] = [];
-      groupedByCategory[category].push(drink);
-    }
-  });
-  
-  // Sort drinks within each category alphabetically
-  Object.keys(groupedByCategory).forEach((category) => {
-    groupedByCategory[category].sort((a, b) => a.title.localeCompare(b.title));
-  });
-  
-  const baseSpiritOrder = [
-    "Vodka",
-    "Gin",
-    "Rum",
-    "Tequila",
-    "Whisky/Whiskey",
-    "Brandy/Cognac",
-    "Liqueur",
-    "Non-alcoholic",
-    "Other",
-  ];
-  const spiritsWithDrinks = baseSpiritOrder.filter(
-    (spirit) => groupedDrinks[spirit] && groupedDrinks[spirit].length > 0
-  );
-  
-  const categoriesWithDrinks = Object.keys(groupedByCategory).sort();
-
-  // Filter drinks based on active filter
-  const getFilteredDrinks = () => {
-    if (activeFilter.type === "category" && activeFilter.value) {
-      return groupedByCategory[activeFilter.value] || [];
-    } else if (activeFilter.type === "spirit" && activeFilter.value) {
-      return groupedDrinks[activeFilter.value] || [];
-    }
-    // For "all", we don't return anything because we'll show the grouped sections
-    return [];
-  };
-
-  const filteredDrinks = getFilteredDrinks();
-
-  const handlePlaceOrder = async (drink: Drink) => {
-    if (customerOrder) {
+  const placeOrder = async (drink: Drink) => {
+    if (currentOrder) {
       alert(t("oneOrderLimit"));
       return;
     }
+
     setLoading(true);
     try {
       await apiCall("/orders", {
@@ -180,8 +80,8 @@ const CustomerInterface: React.FC = () => {
           drinkTitle: drink.title,
         }),
       });
-      setShowOrderPlacedModal(true);
-      await fetchOrders();
+      setShowOrderPlaced(true);
+      await menu.refreshOrders();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to place order");
     } finally {
@@ -189,56 +89,34 @@ const CustomerInterface: React.FC = () => {
     }
   };
 
-  const handleToggleFavourite = async (drink: Drink) => {
+  const toggleFavourite = async (drink: Drink) => {
     if (!currentBar || !customerName) return;
-    
+
     try {
-      if (drink.is_favourite) {
-        // Remove from favourites
-        await apiCall(`/drinks/bar/${currentBar.id}/favourites`, {
-          method: "DELETE",
-          body: JSON.stringify({
-            customerName,
-            drinkId: drink.id,
-          }),
-        });
-      } else {
-        // Add to favourites
-        await apiCall(`/drinks/bar/${currentBar.id}/favourites`, {
-          method: "POST",
-          body: JSON.stringify({
-            customerName,
-            drinkId: drink.id,
-          }),
-        });
-      }
-      
-      // Refresh drinks and favourites
-      await fetchDrinks();
-      await fetchFavourites();
+      await apiCall(`/drinks/bar/${currentBar.id}/favourites`, {
+        method: drink.is_favourite ? "DELETE" : "POST",
+        body: JSON.stringify({ customerName, drinkId: drink.id }),
+      });
+
+      await Promise.all([menu.refreshDrinks(), menu.refreshFavourites()]);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update favourites");
+      setError(
+        err instanceof Error ? err.message : "Failed to update favourites"
+      );
     }
   };
 
-    const handleCancelOrder = async (orderId: number) => {
+  const cancelOrder = async (orderId: number) => {
     if (!currentBar || !customerName) return;
-    
-    const confirmCancel = window.confirm(t("confirmCancelOrder"));
-    if (!confirmCancel) return;
-    
+    if (!window.confirm(t("confirmCancelOrder"))) return;
+
     setLoading(true);
     try {
       await apiCall(`/orders/${orderId}`, {
         method: "DELETE",
-        body: JSON.stringify({
-          barId: currentBar.id,
-          customerName: customerName,
-        }),
+        body: JSON.stringify({ barId: currentBar.id, customerName }),
       });
-      
-      // Refresh orders after canceling
-      await fetchOrders();
+      await menu.refreshOrders();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to cancel order");
     } finally {
@@ -246,73 +124,41 @@ const CustomerInterface: React.FC = () => {
     }
   };
 
-  // Helper to get all in-stock drinks
-  const allInStockDrinks = drinks.filter((d) => d.in_stock);
+  /** Any drink but the one already showing, so a second go feels like one. */
+  const pickRandom = () => {
+    const pool =
+      menu.inStock.length > 1 && randomDrink
+        ? menu.inStock.filter((d) => d.id !== randomDrink.id)
+        : menu.inStock;
 
-  const handleSurpriseMe = () => {
-    if (allInStockDrinks.length === 0) return;
-    const idx = Math.floor(Math.random() * allInStockDrinks.length);
-    setRandomDrink(allInStockDrinks[idx]);
-    setShowRandomModal(true);
+    if (pool.length === 0) return;
+    setRandomDrink(pool[Math.floor(Math.random() * pool.length)]);
   };
 
-  const handleTryAnother = () => {
-    if (allInStockDrinks.length === 0) return;
-    let next;
-    do {
-      next =
-        allInStockDrinks[Math.floor(Math.random() * allInStockDrinks.length)];
-    } while (
-      allInStockDrinks.length > 1 &&
-      randomDrink &&
-      next.id === randomDrink.id
-    );
-    setRandomDrink(next);
+  // The same handful of props go to every section of the menu.
+  const cardActions = {
+    onViewRecipe: setViewingRecipe,
+    onOrder: placeOrder,
+    onToggleFavourite: toggleFavourite,
+    disabled: !!currentOrder || loading,
+    loading,
+    t,
   };
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "new":
-        return <Clock className="w-5 h-5 text-yellow-500" />;
-      case "accepted":
-        return <CheckCircle className="w-5 h-5 text-blue-500" />;
-      case "rejected":
-        return <XCircle className="w-5 h-5 text-red-500" />;
-      case "ready":
-        return <Coffee className="w-5 h-5 text-green-500" />;
-      case "processed":
-        return <Check className="w-5 h-5 text-gray-500" />;
-      default:
-        return null;
-    }
+  const filters = {
+    categories: menu.categories,
+    spirits: menu.spirits,
+    byCategory: menu.byCategory,
+    bySpirit: menu.bySpirit,
+    filter: menu.filter,
+    onFilter: menu.setFilter,
+    t,
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "new":
-        return "bg-yellow-50 border-yellow-200 text-yellow-800";
-      case "accepted":
-        return "bg-blue-50 border-blue-200 text-blue-800";
-      case "rejected":
-        return "bg-red-50 border-red-200 text-red-800";
-      case "ready":
-        return "bg-green-50 border-green-200 text-green-800";
-      default:
-        return "bg-gray-50 border-gray-200 text-gray-800";
-    }
-  };
-
-  // Escape key closes Surprise Me modal
-  useEffect(() => {
-    if (!showRandomModal) return;
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setShowRandomModal(false);
-      }
-    };
-    window.addEventListener("keydown", handleEsc);
-    return () => window.removeEventListener("keydown", handleEsc);
-  }, [showRandomModal]);
+  const nothingToShow =
+    menu.spirits.length === 0 &&
+    menu.categories.length === 0 &&
+    menu.favourites.length === 0;
 
   return (
     <div className="customer-container min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
@@ -322,83 +168,28 @@ const CustomerInterface: React.FC = () => {
           onDismiss={() => setNoticeDismissed(true)}
         />
       )}
-      
-      {/* Order Placed Modal */}
-      {showOrderPlacedModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-          <div className="bg-white rounded-lg shadow-lg p-6 max-w-sm w-full text-center">
-            <div className="text-3xl mb-2">🎉</div>
-            <h2 className="text-lg font-bold mb-2">{t("orderPlaced")}</h2>
-            <p className="mb-4 text-gray-600">Your order has been placed!</p>
-            <button
-              onClick={() => setShowOrderPlacedModal(false)}
-              className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-            >
-              OK
-            </button>
-          </div>
-        </div>
+
+      {showOrderPlaced && (
+        <OrderPlacedModal onClose={() => setShowOrderPlaced(false)} t={t} />
       )}
-      {/* Random Drink Modal */}
-      {showRandomModal && randomDrink && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-          <div className="bg-white rounded-lg shadow-lg p-6 max-w-md w-full text-center">
-            <div className="mb-4">
-              <div className="text-4xl mb-2">🍹</div>
-              <h2 className="text-xl font-bold mb-2">{t("yourRandomDrink")}</h2>
-              <h3 className="text-lg font-semibold text-blue-700 mb-2">
-                {randomDrink.title}
-              </h3>
-              {randomDrink.image_url && (
-                <div className="mx-auto mb-2 rounded-lg overflow-hidden max-h-40 aspect-video relative">
-                  <div className="absolute inset-0 flex items-center justify-center">
-                    <img
-                      src={randomDrink.image_url}
-                      alt={randomDrink.title}
-                      className="w-full h-full object-contain"
-                      style={{
-                        transform: `translate(${randomDrink.image_crop_x || 0}%, ${randomDrink.image_crop_y || 0}%) scale(${randomDrink.image_crop_zoom || 1})`,
-                      }}
-                    />
-                  </div>
-                </div>
-              )}
-              <div className="text-sm text-gray-700 mb-2">
-                {randomDrink.base_spirit && (
-                  <span className="font-medium">
-                    {t("baseSpirit")}: {randomDrink.base_spirit}
-                  </span>
-                )}
-              </div>
-            </div>
-            <div className="flex flex-col gap-2">
-              <button
-                onClick={() => {
-                  setShowRandomModal(false);
-                  handlePlaceOrder(randomDrink);
-                }}
-                disabled={!!customerOrder || loading}
-                className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading ? t("loading") : t("orderThis")}
-              </button>
-              <button
-                onClick={handleTryAnother}
-                className="w-full px-4 py-2 bg-gray-100 text-gray-800 rounded-lg font-medium hover:bg-gray-200 transition-colors"
-              >
-                {t("tryAnother")}
-              </button>
-              <button
-                onClick={() => setShowRandomModal(false)}
-                className="w-full px-4 py-2 bg-white text-gray-500 rounded-lg font-medium border hover:bg-gray-50 transition-colors"
-              >
-                {t("cancel")}
-              </button>
-            </div>
-          </div>
-        </div>
+
+      {randomDrink && (
+        <RandomDrinkModal
+          drink={randomDrink}
+          visible
+          onOrder={() => {
+            const chosen = randomDrink;
+            setRandomDrink(null);
+            placeOrder(chosen);
+          }}
+          onTryAnother={pickRandom}
+          onCancel={() => setRandomDrink(null)}
+          loading={loading}
+          hasOrderInProgress={!!currentOrder}
+          t={t}
+        />
       )}
-      {/* Header */}
+
       <div className="customer-header bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 sticky top-0 z-10 transition-colors duration-200">
         <div className="max-w-4xl mx-auto px-4 py-4">
           <div className="flex justify-between items-center">
@@ -418,309 +209,94 @@ const CustomerInterface: React.FC = () => {
                 </button>
               </div>
             </div>
-            <div className="flex items-center space-x-3">
-              <button
-                onClick={clearSession}
-                className="customer-text-secondary text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm font-medium cursor-pointer"
-              >
-                {t("logout")}
-              </button>
-            </div>
+            <button
+              onClick={clearSession}
+              className="customer-text-secondary text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm font-medium cursor-pointer"
+            >
+              {t("logout")}
+            </button>
           </div>
         </div>
       </div>
 
-      {/* Main content container with left menu and main area */}
       <div className="max-w-4xl mx-auto px-4 py-6 flex space-x-6">
-        {/* Left-hand menu for filtering (desktop only) */}
-        <nav className="hidden md:block w-48 sticky top-24 self-start">
-          <ul className="space-y-2">
-            <li>
-              <button
-                onClick={handleSurpriseMe}
-                disabled={
-                  allInStockDrinks.length === 0 || !!customerOrder || loading
-                }
-                className="w-full flex items-center justify-center px-3 py-2 mb-2 bg-pink-600 text-white rounded font-bold text-base shadow hover:bg-pink-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-              >
-                🎲 {t("surpriseMe")}
-              </button>
-            </li>
-            
-            {/* Show All Filter */}
-            <li>
-              <button
-                onClick={() => setActiveFilter({ type: "all" })}
-                className={`w-full text-left px-3 py-2 rounded font-medium transition-colors ${
-                  activeFilter.type === "all"
-                    ? "bg-blue-100 text-blue-700"
-                    : "hover:bg-gray-100 text-gray-700"
-                }`}
-              >
-                📋 All Drinks
-              </button>
-            </li>
+        <MenuSidebar
+          {...filters}
+          favouriteCount={menu.favourites.length}
+          canSurprise={menu.inStock.length > 0 && !currentOrder && !loading}
+          onSurpriseMe={pickRandom}
+        />
 
-            {/* Favourites - always visible when available */}
-            {favouriteDrinks.length > 0 && (
-              <li>
-                <a
-                  href="#favourites"
-                  className="block px-3 py-2 rounded hover:bg-yellow-100 text-yellow-700 font-medium"
-                >
-                  ⭐ {t("favourites")} ({favouriteDrinks.length})
-                </a>
-              </li>
-            )}
-
-            {/* Categories Filter */}
-            {categoriesWithDrinks.length > 0 && (
-              <>
-                <li className="py-2">
-                  <hr className="border-gray-300" />
-                </li>
-                <li>
-                  <div className="px-3 py-1 text-xs font-semibold text-gray-500 uppercase">
-                    Categories
-                  </div>
-                </li>
-                {categoriesWithDrinks.map((category) => (
-                  <li key={category}>
-                    <button
-                      onClick={() => setActiveFilter({ type: "category", value: category })}
-                      className={`w-full text-left px-3 py-2 rounded font-medium transition-colors ${
-                        activeFilter.type === "category" && activeFilter.value === category
-                          ? "bg-green-100 text-green-700"
-                          : "hover:bg-green-50 text-gray-700"
-                      }`}
-                    >
-                      📁 {category} ({groupedByCategory[category].length})
-                    </button>
-                  </li>
-                ))}
-                <li className="py-2">
-                  <hr className="border-gray-300" />
-                </li>
-                <li>
-                  <div className="px-3 py-1 text-xs font-semibold text-gray-500 uppercase">
-                    Base Spirits
-                  </div>
-                </li>
-              </>
-            )}
-
-            {/* Base Spirits Filter */}
-            {spiritsWithDrinks.map((spirit) => (
-              <li key={spirit}>
-                <button
-                  onClick={() => setActiveFilter({ type: "spirit", value: spirit })}
-                  className={`w-full text-left px-3 py-2 rounded font-medium transition-colors ${
-                    activeFilter.type === "spirit" && activeFilter.value === spirit
-                      ? "bg-blue-100 text-blue-700"
-                      : "hover:bg-blue-50 text-gray-700"
-                  }`}
-                >
-                  {spirit} ({groupedDrinks[spirit].length})
-                </button>
-              </li>
-            ))}
-          </ul>
-        </nav>
-
-        {/* Main drink/order content */}
         <div className="flex-1 space-y-8">
-          {/* Mobile header with filter */}
-          <div className="md:hidden mb-4 space-y-4">
-            <h2 className="text-lg font-bold text-blue-800 text-center py-2">
-              {t("availableDrinks")}
-            </h2>
-            
-            {/* Mobile Filter Dropdown */}
-            <div className="px-4">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Filter Drinks
-              </label>
-              <select
-                value={activeFilter.type === "all" ? "all" : `${activeFilter.type}:${activeFilter.value}`}
-                onChange={(e) => {
-                  const [type, value] = e.target.value.split(':');
-                  if (type === "all") {
-                    setActiveFilter({ type: "all" });
-                  } else {
-                    setActiveFilter({ type: type as "category" | "spirit", value });
-                  }
-                }}
-                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              >
-                <option value="all">📋 All Drinks</option>
-                {categoriesWithDrinks.length > 0 && (
-                  <optgroup label="Categories">
-                    {categoriesWithDrinks.map((category) => (
-                      <option key={category} value={`category:${category}`}>
-                        📁 {category} ({groupedByCategory[category].length})
-                      </option>
-                    ))}
-                  </optgroup>
-                )}
-                <optgroup label="Base Spirits">
-                  {spiritsWithDrinks.map((spirit) => (
-                    <option key={spirit} value={`spirit:${spirit}`}>
-                      {spirit} ({groupedDrinks[spirit].length})
-                    </option>
-                  ))}
-                </optgroup>
-              </select>
-            </div>
-          </div>
+          <MenuFilterSelect {...filters} />
 
-          {/* Current Order Status */}
-          {customerOrder && (
+          {currentOrder && (
             <OrderStatusCard
-              order={customerOrder}
+              order={currentOrder}
               t={t}
-              getStatusIcon={getStatusIcon}
-              getStatusColor={getStatusColor}
-              onCancelOrder={handleCancelOrder}
+              onCancelOrder={cancelOrder}
               loading={loading}
             />
           )}
 
-          {/* Past Orders Section - removed since it's now a separate page */}
-
-          {/* Grouped Available Drinks */}
-          {spiritsWithDrinks.length === 0 && favouriteDrinks.length === 0 && categoriesWithDrinks.length === 0 ? (
+          {nothingToShow ? (
             <div className="p-8 text-center text-gray-500">
               <Coffee className="w-12 h-12 mx-auto mb-3 opacity-50" />
               <p>No drinks available right now</p>
             </div>
           ) : (
             <>
-              {/* Favourites Section - Always show when available */}
-              {favouriteDrinks.length > 0 && (
-                <section
+              {menu.favourites.length > 0 && (
+                <DrinkGrid
                   id="favourites"
-                  className="scroll-mt-24"
-                >
-                  <h2 className="text-2xl font-bold text-yellow-700 mb-4">
-                    ⭐ {t("favourites")}
-                  </h2>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
-                    {favouriteDrinks.map((drink) => (
-                      <DrinkCard
-                        key={drink.id}
-                        drink={drink}
-                        onViewRecipe={setViewingRecipe}
-                        onOrder={handlePlaceOrder}
-                        onToggleFavourite={handleToggleFavourite}
-                        disabled={!!customerOrder || loading}
-                        loading={loading}
-                        t={t}
-                      />
-                    ))}
-                  </div>
-                </section>
-              )}
-              
-              {/* Filtered Drinks Section */}
-              {activeFilter.type === "category" && activeFilter.value && (
-                <section className="scroll-mt-24">
-                  <h2 className="text-2xl font-bold text-green-700 mb-4">
-                    📁 {activeFilter.value}
-                  </h2>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {filteredDrinks.map((drink) => (
-                      <DrinkCard
-                        key={drink.id}
-                        drink={drink}
-                        onViewRecipe={setViewingRecipe}
-                        onOrder={handlePlaceOrder}
-                        onToggleFavourite={handleToggleFavourite}
-                        disabled={!!customerOrder || loading}
-                        loading={loading}
-                        t={t}
-                      />
-                    ))}
-                  </div>
-                </section>
+                  className="mb-8"
+                  heading={`⭐ ${t("favourites")}`}
+                  headingClass="text-yellow-700"
+                  drinks={menu.favourites}
+                  {...cardActions}
+                />
               )}
 
-              {activeFilter.type === "spirit" && activeFilter.value && (
-                <section className="scroll-mt-24">
-                  <h2 className="text-2xl font-bold text-blue-800 mb-4">
-                    {activeFilter.value}
-                  </h2>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {filteredDrinks.map((drink) => (
-                      <DrinkCard
-                        key={drink.id}
-                        drink={drink}
-                        onViewRecipe={setViewingRecipe}
-                        onOrder={handlePlaceOrder}
-                        onToggleFavourite={handleToggleFavourite}
-                        disabled={!!customerOrder || loading}
-                        loading={loading}
-                        t={t}
-                      />
-                    ))}
-                  </div>
-                </section>
+              {menu.filter.type === "category" && (
+                <DrinkGrid
+                  heading={`📁 ${menu.filter.value}`}
+                  headingClass="text-green-700"
+                  drinks={menu.filtered}
+                  {...cardActions}
+                />
               )}
 
-              {/* Show All Categories and Spirits - only when filter is "all" */}
-              {activeFilter.type === "all" && (
+              {menu.filter.type === "spirit" && (
+                <DrinkGrid
+                  heading={menu.filter.value}
+                  headingClass="text-blue-800"
+                  drinks={menu.filtered}
+                  {...cardActions}
+                />
+              )}
+
+              {menu.filter.type === "all" && (
                 <>
-                  {/* Categories Sections */}
-                  {categoriesWithDrinks.map((category) => (
-                    <section
+                  {menu.categories.map((category) => (
+                    <DrinkGrid
                       key={category}
                       id={`category-${category.replace(/[^a-zA-Z0-9]/g, "")}`}
-                      className="scroll-mt-24"
-                    >
-                      <h2 className="text-2xl font-bold text-green-700 mb-4">
-                        📁 {category}
-                      </h2>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {groupedByCategory[category].map((drink) => (
-                          <DrinkCard
-                            key={drink.id}
-                            drink={drink}
-                            onViewRecipe={setViewingRecipe}
-                            onOrder={handlePlaceOrder}
-                            onToggleFavourite={handleToggleFavourite}
-                            disabled={!!customerOrder || loading}
-                            loading={loading}
-                            t={t}
-                          />
-                        ))}
-                      </div>
-                    </section>
+                      heading={`📁 ${category}`}
+                      headingClass="text-green-700"
+                      drinks={menu.byCategory[category]}
+                      {...cardActions}
+                    />
                   ))}
-                  
-                  {/* Base Spirits Sections */}
-                  {spiritsWithDrinks.map((spirit) => (
-                    <section
+
+                  {menu.spirits.map((spirit) => (
+                    <DrinkGrid
                       key={spirit}
                       id={`spirit-${spirit.replace(/[^a-zA-Z0-9]/g, "")}`}
-                      className="scroll-mt-24"
-                    >
-                      <h2 className="text-2xl font-bold text-blue-800 mb-4">
-                        {spirit}
-                      </h2>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {groupedDrinks[spirit].map((drink) => (
-                          <DrinkCard
-                            key={drink.id}
-                            drink={drink}
-                            onViewRecipe={setViewingRecipe}
-                            onOrder={handlePlaceOrder}
-                            onToggleFavourite={handleToggleFavourite}
-                            disabled={!!customerOrder || loading}
-                            loading={loading}
-                            t={t}
-                          />
-                        ))}
-                      </div>
-                    </section>
+                      heading={spirit}
+                      headingClass="text-blue-800"
+                      drinks={menu.bySpirit[spirit]}
+                      {...cardActions}
+                    />
                   ))}
                 </>
               )}

--- a/frontend/src/components/DrinkForm.tsx
+++ b/frontend/src/components/DrinkForm.tsx
@@ -1,17 +1,37 @@
-import React, { useState, useEffect } from "react";
-import { X, Upload, Crop } from "lucide-react";
+import React, { useCallback, useEffect, useState } from "react";
+import { X } from "lucide-react";
 import { useApp } from "../context/AppContext";
 import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
+import { BASE_SPIRITS } from "../utils/spirits";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
 import LazyMDEditor from "./LazyMDEditor";
-import ImageCropper from "./ImageCropper";
+import DrinkImageField, { type DrinkImage } from "./drinkForm/DrinkImageField";
 
 interface DrinkFormProps {
-  drink: Drink | {};
+  /** The drink being changed, or nothing when adding one. */
+  drink: Drink | null;
   onClose: () => void;
 }
+
+const INPUT =
+  "w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent";
+
+/** A labelled row, with an optional note underneath. */
+const Field: React.FC<{
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}> = ({ label, hint, children }) => (
+  <div>
+    <label className="block text-sm font-medium text-gray-700 mb-2">
+      {label}
+    </label>
+    {children}
+    {hint && <p className="mt-1 text-xs text-gray-500">{hint}</p>}
+  </div>
+);
 
 const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
   const {
@@ -27,154 +47,91 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
   } = useApp();
 
   const t = useTranslation(language);
-  const isEditing = "id" in drink && drink.id;
+  const isEditing = drink !== null;
 
-  const [formData, setFormData] = useState({
-    title: "title" in drink ? drink.title || "" : "",
-    image: "image_url" in drink ? drink.image_url || "" : "",
-    recipe: "recipe" in drink ? drink.recipe || "" : "",
-    baseSpirit: "base_spirit" in drink ? drink.base_spirit || "" : "",
-    guestDescription: "guest_description" in drink ? drink.guest_description || "" : "",
-    showRecipeToGuests:
-      "show_recipe_to_guests" in drink ? drink.show_recipe_to_guests === 1 : false,
-    categoryId: "category_id" in drink ? drink.category_id || "" : "",
-    imageCropX: "image_crop_x" in drink ? drink.image_crop_x || 0 : 0,
-    imageCropY: "image_crop_y" in drink ? drink.image_crop_y || 0 : 0,
-    imageCropZoom: "image_crop_zoom" in drink ? drink.image_crop_zoom || 1 : 1,
-  });
+  const [form, setForm] = useState(() => ({
+    title: drink?.title ?? "",
+    baseSpirit: drink?.base_spirit ?? "",
+    categoryId: drink?.category_id ? String(drink.category_id) : "",
+    recipe: drink?.recipe ?? "",
+    guestDescription: drink?.guest_description ?? "",
+    showRecipeToGuests: drink?.show_recipe_to_guests === 1,
+    image: {
+      url: drink?.image_url ?? "",
+      cropX: drink?.image_crop_x ?? 0,
+      cropY: drink?.image_crop_y ?? 0,
+      zoom: drink?.image_crop_zoom ?? 1,
+    } satisfies DrinkImage,
+  }));
 
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [showCropper, setShowCropper] = useState(false);
+  const update = (patch: Partial<typeof form>) =>
+    setForm((prev) => ({ ...prev, ...patch }));
 
-  // Fetch categories when component mounts
-  useEffect(() => {
-    if (currentBar) {
-      fetchCategories();
-    }
-  }, [currentBar]);
+  const barId = currentBar?.id;
 
-  const fetchCategories = async () => {
-    if (!currentBar) return;
+  const fetchCategories = useCallback(async () => {
+    if (!barId) return;
     try {
-      const data = await apiCall(`/categories/bar/${currentBar.id}`);
-      setCategories(data);
+      setCategories(await apiCall(`/categories/bar/${barId}`));
     } catch (err) {
-      console.error("Error fetching categories:", err);
+      console.error("Could not load the categories:", err);
     }
-  };
+  }, [barId, apiCall, setCategories]);
 
-  const handleImageUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
 
-    // Check file size (5MB limit)
-    if (file.size > 5 * 1024 * 1024) {
-      setUploadError("File size must be less than 5MB");
-      return;
-    }
-
-    // Check file type
-    if (!file.type.startsWith("image/")) {
-      setUploadError("Only image files are allowed");
-      return;
-    }
-
-    setUploadError(null);
-    const uploadFormData = new FormData();
-    uploadFormData.append("image", file);
-
-    try {
-      setLoading(true);
-      const response = await fetch("/api/drinks/upload-image", {
-        method: "POST",
-        body: uploadFormData,
-      });
-
-      if (!response.ok) {
-        throw new Error("Upload failed");
-      }
-
-      const data = await response.json();
-      // Reset crop parameters when uploading a new image
-      setFormData((prev) => ({ 
-        ...prev, 
-        image: data.imageUrl,
-        imageCropX: 0,
-        imageCropY: 0,
-        imageCropZoom: 1,
-      }));
-    } catch {
-      setUploadError("Failed to upload image. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  };
+  // Escape closes the form.
+  useEffect(() => {
+    const close = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [onClose]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!formData.title.trim()) {
-      setError("Drink title is required");
-      return;
-    }
+    const missing =
+      (!form.title.trim() && "Drink title is required") ||
+      (!form.recipe.trim() && "Recipe is required") ||
+      (!form.baseSpirit.trim() && "Base spirit is required");
 
-    if (!formData.recipe.trim()) {
-      setError("Recipe is required");
-      return;
-    }
-
-    if (!formData.baseSpirit.trim()) {
-      setError("Base spirit is required");
+    if (missing) {
+      setError(missing);
       return;
     }
 
     setLoading(true);
     try {
-      if (isEditing) {
-        // Update existing drink
-        const updatedDrink = await apiCall(`/drinks/${drink.id}`, {
-          method: "PUT",
+      // Adding and changing send the same thing; only where to differs.
+      const saved: Drink = await apiCall(
+        isEditing ? `/drinks/${drink.id}` : "/drinks",
+        {
+          method: isEditing ? "PUT" : "POST",
           body: JSON.stringify({
             barId: currentBar!.id,
-            title: formData.title.trim(),
-            imageUrl: formData.image.trim() || null,
-            recipe: formData.recipe.trim(),
-            baseSpirit: formData.baseSpirit.trim(),
-            guestDescription: formData.guestDescription.trim() || null,
-            showRecipeToGuests: formData.showRecipeToGuests,
-            categoryId: formData.categoryId || null,
-            imageCropX: formData.imageCropX,
-            imageCropY: formData.imageCropY,
-            imageCropZoom: formData.imageCropZoom,
+            title: form.title.trim(),
+            imageUrl: form.image.url.trim() || null,
+            recipe: form.recipe.trim(),
+            baseSpirit: form.baseSpirit.trim(),
+            guestDescription: form.guestDescription.trim() || null,
+            showRecipeToGuests: form.showRecipeToGuests,
+            categoryId: form.categoryId || null,
+            imageCropX: form.image.cropX,
+            imageCropY: form.image.cropY,
+            imageCropZoom: form.image.zoom,
           }),
-        });
+        }
+      );
 
-        setDrinks((prev) =>
-          prev.map((d) => (d.id === drink.id ? updatedDrink : d))
-        );
-      } else {
-        // Create new drink
-        const newDrink = await apiCall("/drinks", {
-          method: "POST",
-          body: JSON.stringify({
-            barId: currentBar!.id,
-            title: formData.title.trim(),
-            imageUrl: formData.image.trim() || null,
-            recipe: formData.recipe.trim(),
-            baseSpirit: formData.baseSpirit.trim(),
-            guestDescription: formData.guestDescription.trim() || null,
-            showRecipeToGuests: formData.showRecipeToGuests,
-            categoryId: formData.categoryId || null,
-            imageCropX: formData.imageCropX,
-            imageCropY: formData.imageCropY,
-            imageCropZoom: formData.imageCropZoom,
-          }),
-        });
-
-        setDrinks((prev) => [...prev, newDrink]);
-      }
+      setDrinks((prev) =>
+        isEditing
+          ? prev.map((d) => (d.id === drink.id ? saved : d))
+          : [...prev, saved]
+      );
 
       onClose();
     } catch (err) {
@@ -184,21 +141,9 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
     }
   };
 
-  // Close modal on Escape key
-  useEffect(() => {
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", handleEsc);
-    return () => window.removeEventListener("keydown", handleEsc);
-  }, [onClose]);
-
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden">
-        {/* Header */}
         <div className="flex items-center justify-between p-6 border-b">
           <h2 className="text-2xl font-bold text-gray-800">
             {isEditing ? t("editDrink") : t("addDrink")}
@@ -211,71 +156,41 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
           </button>
         </div>
 
-        {/* Content */}
         <div className="flex flex-col lg:flex-row max-h-[calc(90vh-180px)]">
-          {/* Form Side */}
           <div className="flex-1 p-6 overflow-y-auto">
             <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Title */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {t("drinkTitle")} *
-                </label>
+              <Field label={`${t("drinkTitle")} *`}>
                 <input
                   type="text"
-                  value={formData.title}
-                  onChange={(e) =>
-                    setFormData((prev) => ({ ...prev, title: e.target.value }))
-                  }
+                  value={form.title}
+                  onChange={(e) => update({ title: e.target.value })}
                   placeholder="e.g., Old Fashioned"
-                  className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className={INPUT}
                   required
                 />
-              </div>
+              </Field>
 
-              {/* Base Spirit */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Base Spirit *
-                </label>
+              <Field label="Base Spirit *">
                 <select
-                  value={formData.baseSpirit}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      baseSpirit: e.target.value,
-                    }))
-                  }
-                  className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  value={form.baseSpirit}
+                  onChange={(e) => update({ baseSpirit: e.target.value })}
+                  className={INPUT}
                   required
                 >
                   <option value="">Select base spirit</option>
-                  <option value="Vodka">Vodka</option>
-                  <option value="Gin">Gin</option>
-                  <option value="Rum">Rum</option>
-                  <option value="Tequila">Tequila</option>
-                  <option value="Whisky/Whiskey">Whisky/Whiskey</option>
-                  <option value="Brandy/Cognac">Brandy/Cognac</option>
-                  <option value="Liqueur">Liqueur</option>
-                  <option value="Non-alcoholic">Non-alcoholic</option>
-                  <option value="Other">Other</option>
+                  {BASE_SPIRITS.map((spirit) => (
+                    <option key={spirit} value={spirit}>
+                      {spirit}
+                    </option>
+                  ))}
                 </select>
-              </div>
+              </Field>
 
-              {/* Category */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Category
-                </label>
+              <Field label="Category">
                 <select
-                  value={formData.categoryId}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      categoryId: e.target.value,
-                    }))
-                  }
-                  className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  value={form.categoryId}
+                  onChange={(e) => update({ categoryId: e.target.value })}
+                  className={INPUT}
                 >
                   <option value="">No category</option>
                   {categories.map((category) => (
@@ -284,192 +199,64 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
                     </option>
                   ))}
                 </select>
-              </div>
+              </Field>
 
-              {/* Image Upload */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {t("drinkImage")}
-                </label>
+              <DrinkImageField
+                value={form.image}
+                onChange={(image) => update({ image })}
+                loading={loading}
+                setLoading={setLoading}
+                t={t}
+              />
 
-                {/* Upload Area */}
-                <div className="space-y-4">
-                  <div className="flex items-center justify-center w-full">
-                    <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
-                      <div className="flex flex-col items-center justify-center pt-5 pb-6">
-                        <Upload className="w-8 h-8 mb-2 text-gray-500" />
-                        <p className="mb-2 text-sm text-gray-500">
-                          <span className="font-semibold">
-                            {t("uploadImage")}
-                          </span>
-                        </p>
-                        <p className="text-xs text-gray-500">
-                          PNG, JPG, GIF up to 5MB
-                        </p>
-                      </div>
-                      <input
-                        type="file"
-                        className="hidden"
-                        accept="image/png, image/jpeg, image/jpg, image/gif, image/webp, image/avif, image/svg+xml, image/bmp, image/tiff, image/x-icon, image/heic, image/heif, image/*"
-                        onChange={handleImageUpload}
-                        disabled={loading}
-                      />
-                    </label>
-                  </div>
-
-                  {uploadError && (
-                    <p className="text-sm text-red-600">{uploadError}</p>
-                  )}
-
-                  <div className="text-center text-gray-500 text-sm">
-                    {t("or")}
-                  </div>
-
-                  <input
-                    type="url"
-                    value={formData.image}
-                    onChange={(e) => {
-                      const newImageUrl = e.target.value;
-                      // Reset crop parameters when image URL changes
-                      setFormData((prev) => ({
-                        ...prev,
-                        image: newImageUrl,
-                        imageCropX: 0,
-                        imageCropY: 0,
-                        imageCropZoom: 1,
-                      }));
-                    }}
-                    placeholder="https://example.com/image.jpg"
-                    className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  />
-
-                  {/* Image Preview */}
-                  {formData.image && (
-                    <div className="mt-4 space-y-2">
-                      <div className="relative w-full rounded-lg overflow-hidden bg-gray-100" style={{ aspectRatio: '16/9' }}>
-                        <div className="absolute inset-0 flex items-center justify-center">
-                          <img
-                            src={formData.image}
-                            alt="Preview"
-                            className="w-full h-full object-contain"
-                            style={{
-                              transform: `translate(${formData.imageCropX}%, ${formData.imageCropY}%) scale(${formData.imageCropZoom})`,
-                            }}
-                            onError={(e) => {
-                              e.currentTarget.style.display = "none";
-                            }}
-                          />
-                        </div>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setShowCropper(true)}
-                        className="w-full flex items-center justify-center space-x-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
-                      >
-                        <Crop className="w-4 h-4" />
-                        <span>Crop & Position</span>
-                      </button>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Image Cropper Modal */}
-              {showCropper && formData.image && (
-                <ImageCropper
-                  imageUrl={formData.image}
-                  initialCrop={{ x: formData.imageCropX, y: formData.imageCropY }}
-                  initialZoom={formData.imageCropZoom}
-                  onSave={(crop, zoom) => {
-                    setFormData((prev) => ({
-                      ...prev,
-                      imageCropX: crop.x,
-                      imageCropY: crop.y,
-                      imageCropZoom: zoom,
-                    }));
-                    setShowCropper(false);
+              <Field
+                label={`${t("recipe")} *`}
+                hint="Use Markdown formatting for better presentation"
+              >
+                <LazyMDEditor
+                  value={form.recipe}
+                  onChange={(value) => update({ recipe: value || "" })}
+                  height={300}
+                  textareaProps={{
+                    placeholder:
+                      "## Drink Name\n\n**Ingredients:**\n- 2 oz Spirit\n- 1 oz Mixer\n- Garnish\n\n**Instructions:**\n1. Step 1\n2. Step 2\n3. Serve and enjoy!",
                   }}
-                  onCancel={() => setShowCropper(false)}
                 />
-              )}
+              </Field>
 
-              {/* Recipe */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {t("recipe")} *
-                </label>
-                <div className="relative">
-                  <LazyMDEditor
-                    value={formData.recipe}
-                    onChange={(value) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        recipe: value || "",
-                      }))
-                    }
-                    height={300}
-                    textareaProps={{
-                      placeholder:
-                        "## Drink Name\n\n**Ingredients:**\n- 2 oz Spirit\n- 1 oz Mixer\n- Garnish\n\n**Instructions:**\n1. Step 1\n2. Step 2\n3. Serve and enjoy!",
-                    }}
-                  />
-                </div>
-                <p className="mt-1 text-xs text-gray-500">
-                  Use Markdown formatting for better presentation
-                </p>
-              </div>
-
-              {/* Guest Description */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {t("guestDescription")}
-                </label>
+              <Field
+                label={t("guestDescription")}
+                hint={t("guestDescriptionHelp")}
+              >
                 <textarea
-                  value={formData.guestDescription}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      guestDescription: e.target.value,
-                    }))
-                  }
+                  value={form.guestDescription}
+                  onChange={(e) => update({ guestDescription: e.target.value })}
                   rows={4}
                   placeholder="Optional description shown to guests..."
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-vertical"
                 />
-                <p className="mt-1 text-xs text-gray-500">
-                  {t("guestDescriptionHelp")}
-                </p>
-              </div>
+              </Field>
 
-              {/* Show Recipe to Guests Toggle */}
-              <div>
-                <label className="flex items-center space-x-3">
-                  <input
-                    type="checkbox"
-                    checked={formData.showRecipeToGuests}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        showRecipeToGuests: e.target.checked,
-                      }))
-                    }
-                    className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                  />
-                  <div>
-                    <span className="text-sm font-medium text-gray-700">
-                      {t("showRecipeToGuests")}
-                    </span>
-                    <p className="text-xs text-gray-500">
-                      {t("showRecipeHelp")}
-                    </p>
-                  </div>
-                </label>
-              </div>
+              <label className="flex items-center space-x-3">
+                <input
+                  type="checkbox"
+                  checked={form.showRecipeToGuests}
+                  onChange={(e) =>
+                    update({ showRecipeToGuests: e.target.checked })
+                  }
+                  className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <div>
+                  <span className="text-sm font-medium text-gray-700">
+                    {t("showRecipeToGuests")}
+                  </span>
+                  <p className="text-xs text-gray-500">{t("showRecipeHelp")}</p>
+                </div>
+              </label>
             </form>
           </div>
         </div>
 
-        {/* Footer */}
         <div className="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-4 p-6 border-t bg-gray-50">
           <button
             type="button"
@@ -480,9 +267,7 @@ const DrinkForm: React.FC<DrinkFormProps> = ({ drink, onClose }) => {
           </button>
           <button
             onClick={handleSubmit}
-            disabled={
-              loading || !formData.title.trim() || !formData.recipe.trim()
-            }
+            disabled={loading || !form.title.trim() || !form.recipe.trim()}
             className="w-full sm:w-auto px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? t("loading") : t("save")}

--- a/frontend/src/components/MenuTab.tsx
+++ b/frontend/src/components/MenuTab.tsx
@@ -112,7 +112,7 @@ const MenuTab: React.FC = () => {
               <option value="category">Sort: Category</option>
             </select>
             <button
-              onClick={() => setEditingDrink({})}
+              onClick={() => setEditingDrink("new")}
               className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2 w-full sm:w-auto justify-center"
             >
               <Plus className="w-4 h-4" />
@@ -133,7 +133,7 @@ const MenuTab: React.FC = () => {
             Start building your menu by adding your first drink
           </p>
           <button
-            onClick={() => setEditingDrink({})}
+            onClick={() => setEditingDrink("new")}
             className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors inline-flex items-center space-x-2"
           >
             <Plus className="w-4 h-4" />

--- a/frontend/src/components/OrderStatusCard.tsx
+++ b/frontend/src/components/OrderStatusCard.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { X } from "lucide-react";
+import type { Order } from "../types";
+import { statusCardWithText, statusIcon } from "../utils/orderStatus";
 import { translations } from "../utils/translations";
 
 interface OrderStatusCardProps {
-  order: any;
+  order: Order;
   t: (key: keyof typeof translations.en) => string;
-  getStatusIcon: (status: string) => React.ReactNode;
-  getStatusColor: (status: string) => string;
   onCancelOrder?: (orderId: number) => void;
   loading?: boolean;
 }
@@ -14,14 +14,12 @@ interface OrderStatusCardProps {
 const OrderStatusCard: React.FC<OrderStatusCardProps> = ({
   order,
   t,
-  getStatusIcon,
-  getStatusColor,
   onCancelOrder,
   loading = false,
 }) => (
-  <div className={`rounded-lg border-2 p-4 ${getStatusColor(order.status)}`}>
+  <div className={`rounded-lg border-2 p-4 ${statusCardWithText(order.status)}`}>
     <div className="flex items-center space-x-3">
-      {getStatusIcon(order.status)}
+      {statusIcon(order.status)}
       <div className="flex-1">
         <h3 className="font-semibold">{t("yourOrder")}</h3>
         <p className="text-sm opacity-90">{order.drink_title}</p>
@@ -50,6 +48,6 @@ const OrderStatusCard: React.FC<OrderStatusCardProps> = ({
       </div>
     </div>
   </div>
-); 
+);
 
 export default OrderStatusCard;

--- a/frontend/src/components/OrdersTab.tsx
+++ b/frontend/src/components/OrdersTab.tsx
@@ -1,16 +1,15 @@
 import React, { useState } from "react";
 import {
-  Clock,
-  CheckCircle,
-  XCircle,
-  Coffee,
-  Check,
-  User,
   Calendar,
+  Check,
   ChevronDown,
   ChevronUp,
+  Clock,
+  Coffee,
+  User,
 } from "lucide-react";
 import { useApp } from "../context/AppContext";
+import { statusCard, statusIcon } from "../utils/orderStatus";
 import { useTranslation } from "../utils/translations";
 
 const OrdersTab: React.FC = () => {
@@ -61,40 +60,6 @@ const OrdersTab: React.FC = () => {
       setError(err instanceof Error ? err.message : "Failed to update order");
     } finally {
       setLoading(false);
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "new":
-        return <Clock className="w-5 h-5 text-yellow-500" />;
-      case "accepted":
-        return <CheckCircle className="w-5 h-5 text-blue-500" />;
-      case "rejected":
-        return <XCircle className="w-5 h-5 text-red-500" />;
-      case "ready":
-        return <Coffee className="w-5 h-5 text-green-500" />;
-      case "processed":
-        return <Check className="w-5 h-5 text-gray-500" />;
-      default:
-        return null;
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "new":
-        return "bg-yellow-50 border-yellow-200";
-      case "accepted":
-        return "bg-blue-50 border-blue-200";
-      case "rejected":
-        return "bg-red-50 border-red-200";
-      case "ready":
-        return "bg-green-50 border-green-200";
-      case "processed":
-        return "bg-gray-50 border-gray-200";
-      default:
-        return "bg-white border-gray-200";
     }
   };
 
@@ -169,11 +134,11 @@ const OrdersTab: React.FC = () => {
             pendingOrders.map((order) => (
               <div
                 key={order.id}
-                className={`p-4 ${getStatusColor(order.status)}`}
+                className={`p-4 ${statusCard(order.status)}`}
               >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-4">
-                    {getStatusIcon(order.status)}
+                    {statusIcon(order.status)}
                     <div className="flex-1">
                       <div className="flex items-center space-x-2">
                         <User className="w-4 h-4 text-gray-500" />

--- a/frontend/src/components/RandomDrinkModal.tsx
+++ b/frontend/src/components/RandomDrinkModal.tsx
@@ -9,7 +9,8 @@ interface RandomDrinkModalProps {
   onTryAnother: () => void;
   onCancel: () => void;
   loading: boolean;
-  customerOrder: any;
+  /** The guest may only have one drink on the go at a time. */
+  hasOrderInProgress: boolean;
   t: (key: keyof typeof translations.en) => string;
 }
 
@@ -20,7 +21,7 @@ const RandomDrinkModal: React.FC<RandomDrinkModalProps> = ({
   onTryAnother,
   onCancel,
   loading,
-  customerOrder,
+  hasOrderInProgress,
   t,
 }) => {
   if (!visible || !drink) return null;
@@ -58,7 +59,7 @@ const RandomDrinkModal: React.FC<RandomDrinkModalProps> = ({
         <div className="flex flex-col gap-2">
           <button
             onClick={onOrder}
-            disabled={!!customerOrder || loading}
+            disabled={hasOrderInProgress || loading}
             className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {loading ? t("loading") : t("orderThis")}

--- a/frontend/src/components/analytics/RankedBars.tsx
+++ b/frontend/src/components/analytics/RankedBars.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+export interface Ranked {
+  label: string;
+  value: number;
+}
+
+interface RankedBarsProps {
+  icon: React.ReactNode;
+  heading: string;
+  rows: Ranked[];
+  /** Shown instead of the bars when there is nothing to count yet. */
+  emptyIcon: React.ReactNode;
+  emptyMessage: string;
+  barColour: string;
+}
+
+/** A short league table with a bar behind each number. */
+const RankedBars: React.FC<RankedBarsProps> = ({
+  icon,
+  heading,
+  rows,
+  emptyIcon,
+  emptyMessage,
+  barColour,
+}) => {
+  const top = rows.slice(0, 5);
+  const most = Math.max(0, ...top.map((row) => row.value));
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border p-6">
+      <div className="flex items-center mb-6">
+        {icon}
+        <h3 className="text-lg font-semibold text-gray-800">{heading}</h3>
+      </div>
+
+      {top.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          {emptyIcon}
+          <p>{emptyMessage}</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {top.map((row, index) => (
+            <div key={row.label} className="flex items-center justify-between">
+              <div className="flex items-center space-x-3 flex-1 min-w-0">
+                <span className="text-sm font-medium text-gray-500 w-6">
+                  #{index + 1}
+                </span>
+                <span className="font-medium text-gray-800 truncate">
+                  {row.label}
+                </span>
+              </div>
+              <div className="flex items-center space-x-3 ml-4">
+                <div className="w-24 bg-gray-200 rounded-full h-2">
+                  <div
+                    className={`h-2 rounded-full transition-all duration-500 ${barColour}`}
+                    style={{
+                      width: `${most > 0 ? (row.value / most) * 100 : 0}%`,
+                    }}
+                  />
+                </div>
+                <span className="text-sm text-gray-600 w-8 text-right">
+                  {row.value}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RankedBars;

--- a/frontend/src/components/analytics/StatCard.tsx
+++ b/frontend/src/components/analytics/StatCard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  /** Tailwind classes for the tinted circle behind the icon. */
+  tint: string;
+  label: string;
+  value: React.ReactNode;
+  /** Long values, such as a drink name, get the smaller size. */
+  small?: boolean;
+}
+
+/** One of the boxes along the top of the reports. */
+const StatCard: React.FC<StatCardProps> = ({
+  icon,
+  tint,
+  label,
+  value,
+  small = false,
+}) => (
+  <div className="bg-white rounded-lg shadow-sm border p-6">
+    <div className="flex items-center">
+      <div className={`p-3 rounded-lg ${tint}`}>{icon}</div>
+      <div className="ml-4 min-w-0">
+        <p className="text-sm font-medium text-gray-600">{label}</p>
+        <p
+          className={`font-bold text-gray-900 ${
+            small ? "text-lg truncate" : "text-2xl"
+          }`}
+        >
+          {value}
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+export default StatCard;

--- a/frontend/src/components/analytics/StatList.tsx
+++ b/frontend/src/components/analytics/StatList.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface StatListProps {
+  heading: string;
+  rows: Array<{ label: string; value: React.ReactNode }>;
+}
+
+/** A short list of label-and-number pairs. */
+const StatList: React.FC<StatListProps> = ({ heading, rows }) => (
+  <div>
+    <h4 className="font-medium text-gray-700 mb-3">{heading}</h4>
+    <div className="space-y-2">
+      {rows.map((row) => (
+        <div key={row.label} className="flex justify-between">
+          <span className="text-sm text-gray-600">{row.label}</span>
+          <span className="text-sm font-medium truncate max-w-32">
+            {row.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default StatList;

--- a/frontend/src/components/customer/DrinkGrid.tsx
+++ b/frontend/src/components/customer/DrinkGrid.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import DrinkCard from "../DrinkCard";
+import type { Drink } from "../../types";
+import { translations } from "../../utils/translations";
+
+interface DrinkGridProps {
+  drinks: Drink[];
+  heading: string;
+  headingClass: string;
+  /** Set when the section is a jump target for the menu on the left. */
+  id?: string;
+  /** Extra spacing, where a section wants setting apart from the next. */
+  className?: string;
+  onViewRecipe: (drink: Drink) => void;
+  onOrder: (drink: Drink) => void;
+  onToggleFavourite: (drink: Drink) => void;
+  disabled: boolean;
+  loading: boolean;
+  t: (key: keyof typeof translations.en) => string;
+}
+
+/** One headed section of drinks. The guest's menu is made of these. */
+const DrinkGrid: React.FC<DrinkGridProps> = ({
+  drinks,
+  heading,
+  headingClass,
+  id,
+  className = "",
+  ...card
+}) => (
+  <section id={id} className={`scroll-mt-24 ${className}`}>
+    <h2 className={`text-2xl font-bold mb-4 ${headingClass}`}>{heading}</h2>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {drinks.map((drink) => (
+        <DrinkCard key={drink.id} drink={drink} {...card} />
+      ))}
+    </div>
+  </section>
+);
+
+export default DrinkGrid;

--- a/frontend/src/components/customer/MenuFilters.tsx
+++ b/frontend/src/components/customer/MenuFilters.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import type { Drink } from "../../types";
+import type { MenuFilter } from "../../hooks/useGuestMenu";
+import { translations } from "../../utils/translations";
+
+interface FilterProps {
+  categories: string[];
+  spirits: string[];
+  byCategory: Record<string, Drink[]>;
+  bySpirit: Record<string, Drink[]>;
+  filter: MenuFilter;
+  onFilter: (filter: MenuFilter) => void;
+  t: (key: keyof typeof translations.en) => string;
+}
+
+interface SidebarProps extends FilterProps {
+  favouriteCount: number;
+  canSurprise: boolean;
+  onSurpriseMe: () => void;
+}
+
+const isChosen = (filter: MenuFilter, type: string, value: string): boolean =>
+  filter.type === type && "value" in filter && filter.value === value;
+
+const button = (chosen: boolean, chosenClass: string, hoverClass: string) =>
+  `w-full text-left px-3 py-2 rounded font-medium transition-colors ${
+    chosen ? chosenClass : `${hoverClass} text-gray-700`
+  }`;
+
+const Divider: React.FC<{ label: string }> = ({ label }) => (
+  <>
+    <li className="py-2">
+      <hr className="border-gray-300" />
+    </li>
+    <li>
+      <div className="px-3 py-1 text-xs font-semibold text-gray-500 uppercase">
+        {label}
+      </div>
+    </li>
+  </>
+);
+
+/** The menu down the side, on a wide screen. */
+export const MenuSidebar: React.FC<SidebarProps> = ({
+  categories,
+  spirits,
+  byCategory,
+  bySpirit,
+  filter,
+  onFilter,
+  favouriteCount,
+  canSurprise,
+  onSurpriseMe,
+  t,
+}) => (
+  <nav className="hidden md:block w-48 sticky top-24 self-start">
+    <ul className="space-y-2">
+      <li>
+        <button
+          onClick={onSurpriseMe}
+          disabled={!canSurprise}
+          className="w-full flex items-center justify-center px-3 py-2 mb-2 bg-pink-600 text-white rounded font-bold text-base shadow hover:bg-pink-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+        >
+          🎲 {t("surpriseMe")}
+        </button>
+      </li>
+
+      <li>
+        <button
+          onClick={() => onFilter({ type: "all" })}
+          className={button(
+            filter.type === "all",
+            "bg-blue-100 text-blue-700",
+            "hover:bg-gray-100"
+          )}
+        >
+          📋 All Drinks
+        </button>
+      </li>
+
+      {favouriteCount > 0 && (
+        <li>
+          <a
+            href="#favourites"
+            className="block px-3 py-2 rounded hover:bg-yellow-100 text-yellow-700 font-medium"
+          >
+            ⭐ {t("favourites")} ({favouriteCount})
+          </a>
+        </li>
+      )}
+
+      {categories.length > 0 && (
+        <>
+          <Divider label="Categories" />
+          {categories.map((category) => (
+            <li key={category}>
+              <button
+                onClick={() => onFilter({ type: "category", value: category })}
+                className={button(
+                  isChosen(filter, "category", category),
+                  "bg-green-100 text-green-700",
+                  "hover:bg-green-50"
+                )}
+              >
+                📁 {category} ({byCategory[category].length})
+              </button>
+            </li>
+          ))}
+          <Divider label="Base Spirits" />
+        </>
+      )}
+
+      {spirits.map((spirit) => (
+        <li key={spirit}>
+          <button
+            onClick={() => onFilter({ type: "spirit", value: spirit })}
+            className={button(
+              isChosen(filter, "spirit", spirit),
+              "bg-blue-100 text-blue-700",
+              "hover:bg-blue-50"
+            )}
+          >
+            {spirit} ({bySpirit[spirit].length})
+          </button>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+/** The same choices as a dropdown, on a phone. */
+export const MenuFilterSelect: React.FC<FilterProps> = ({
+  categories,
+  spirits,
+  byCategory,
+  bySpirit,
+  filter,
+  onFilter,
+  t,
+}) => (
+  <div className="md:hidden mb-4 space-y-4">
+    <h2 className="text-lg font-bold text-blue-800 text-center py-2">
+      {t("availableDrinks")}
+    </h2>
+
+    <div className="px-4">
+      <label className="block text-sm font-medium text-gray-700 mb-2">
+        Filter Drinks
+      </label>
+      <select
+        value={filter.type === "all" ? "all" : `${filter.type}:${filter.value}`}
+        onChange={(e) => {
+          const [type, ...rest] = e.target.value.split(":");
+          // Rejoined, because a category may have a colon in its name.
+          const value = rest.join(":");
+
+          onFilter(
+            type === "all"
+              ? { type: "all" }
+              : { type: type as "category" | "spirit", value }
+          );
+        }}
+        className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      >
+        <option value="all">📋 All Drinks</option>
+        {categories.length > 0 && (
+          <optgroup label="Categories">
+            {categories.map((category) => (
+              <option key={category} value={`category:${category}`}>
+                📁 {category} ({byCategory[category].length})
+              </option>
+            ))}
+          </optgroup>
+        )}
+        <optgroup label="Base Spirits">
+          {spirits.map((spirit) => (
+            <option key={spirit} value={`spirit:${spirit}`}>
+              {spirit} ({bySpirit[spirit].length})
+            </option>
+          ))}
+        </optgroup>
+      </select>
+    </div>
+  </div>
+);

--- a/frontend/src/components/customer/OrderPlacedModal.tsx
+++ b/frontend/src/components/customer/OrderPlacedModal.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { translations } from "../../utils/translations";
+
+interface OrderPlacedModalProps {
+  onClose: () => void;
+  t: (key: keyof typeof translations.en) => string;
+}
+
+const OrderPlacedModal: React.FC<OrderPlacedModalProps> = ({ onClose, t }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+    <div className="bg-white rounded-lg shadow-lg p-6 max-w-sm w-full text-center">
+      <div className="text-3xl mb-2">🎉</div>
+      <h2 className="text-lg font-bold mb-2">{t("orderPlaced")}</h2>
+      <p className="mb-4 text-gray-600">Your order has been placed!</p>
+      <button
+        onClick={onClose}
+        className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+      >
+        OK
+      </button>
+    </div>
+  </div>
+);
+
+export default OrderPlacedModal;

--- a/frontend/src/components/drinkForm/DrinkImageField.tsx
+++ b/frontend/src/components/drinkForm/DrinkImageField.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from "react";
+import { Crop, Upload } from "lucide-react";
+import ImageCropper from "../ImageCropper";
+import { translations } from "../../utils/translations";
+
+export interface DrinkImage {
+  url: string;
+  cropX: number;
+  cropY: number;
+  zoom: number;
+}
+
+interface DrinkImageFieldProps {
+  value: DrinkImage;
+  onChange: (value: DrinkImage) => void;
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+  t: (key: keyof typeof translations.en) => string;
+}
+
+const MAX_SIZE = 5 * 1024 * 1024;
+
+/** A fresh picture starts uncropped. */
+const uncropped = (url: string): DrinkImage => ({
+  url,
+  cropX: 0,
+  cropY: 0,
+  zoom: 1,
+});
+
+/** Picking the photo for a drink: upload one, or paste an address. */
+const DrinkImageField: React.FC<DrinkImageFieldProps> = ({
+  value,
+  onChange,
+  loading,
+  setLoading,
+  t,
+}) => {
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [showCropper, setShowCropper] = useState(false);
+
+  const upload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > MAX_SIZE) {
+      setUploadError("File size must be less than 5MB");
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      setUploadError("Only image files are allowed");
+      return;
+    }
+
+    setUploadError(null);
+    const body = new FormData();
+    body.append("image", file);
+
+    try {
+      setLoading(true);
+      const response = await fetch("/api/drinks/upload-image", {
+        method: "POST",
+        body,
+      });
+
+      if (!response.ok) throw new Error("Upload failed");
+
+      const { imageUrl } = await response.json();
+      onChange(uncropped(imageUrl));
+    } catch {
+      setUploadError("Failed to upload image. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-2">
+        {t("drinkImage")}
+      </label>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-center w-full">
+          <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
+            <div className="flex flex-col items-center justify-center pt-5 pb-6">
+              <Upload className="w-8 h-8 mb-2 text-gray-500" />
+              <p className="mb-2 text-sm text-gray-500">
+                <span className="font-semibold">{t("uploadImage")}</span>
+              </p>
+              <p className="text-xs text-gray-500">PNG, JPG, GIF up to 5MB</p>
+            </div>
+            <input
+              type="file"
+              className="hidden"
+              accept="image/*"
+              onChange={upload}
+              disabled={loading}
+            />
+          </label>
+        </div>
+
+        {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+
+        <div className="text-center text-gray-500 text-sm">{t("or")}</div>
+
+        <input
+          type="url"
+          value={value.url}
+          onChange={(e) => onChange(uncropped(e.target.value))}
+          placeholder="https://example.com/image.jpg"
+          className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+
+        {value.url && (
+          <div className="mt-4 space-y-2">
+            <div
+              className="relative w-full rounded-lg overflow-hidden bg-gray-100"
+              style={{ aspectRatio: "16/9" }}
+            >
+              <div className="absolute inset-0 flex items-center justify-center">
+                <img
+                  src={value.url}
+                  alt="Preview"
+                  className="w-full h-full object-contain"
+                  style={{
+                    transform: `translate(${value.cropX}%, ${value.cropY}%) scale(${value.zoom})`,
+                  }}
+                  onError={(e) => {
+                    e.currentTarget.style.display = "none";
+                  }}
+                />
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowCropper(true)}
+              className="w-full flex items-center justify-center space-x-2 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              <Crop className="w-4 h-4" />
+              <span>Crop &amp; Position</span>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showCropper && value.url && (
+        <ImageCropper
+          imageUrl={value.url}
+          initialCrop={{ x: value.cropX, y: value.cropY }}
+          initialZoom={value.zoom}
+          onSave={(crop, zoom) => {
+            onChange({ ...value, cropX: crop.x, cropY: crop.y, zoom });
+            setShowCropper(false);
+          }}
+          onCancel={() => setShowCropper(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DrinkImageField;

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,5 +1,6 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -271,25 +272,30 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     validateSession();
   }, [userType, currentBar, customerName]);
 
-  // API helper function
-  const apiCall = async (endpoint: string, options: RequestInit = {}) => {
-    const response = await fetch(`${API_BASE}${endpoint}`, {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-      ...options,
-    });
+  // Talks to the API. It keeps the same identity for the life of the app,
+  // because anything that reloads when this changes would otherwise reload on
+  // every single render.
+  const apiCall = useCallback(
+    async (endpoint: string, options: RequestInit = {}) => {
+      const response = await fetch(`${API_BASE}${endpoint}`, {
+        headers: {
+          "Content-Type": "application/json",
+          ...options.headers,
+        },
+        ...options,
+      });
 
-    if (!response.ok) {
-      const errorData = await response
-        .json()
-        .catch(() => ({ error: "Unknown error" }));
-      throw new Error(errorData.error || `HTTP ${response.status}`);
-    }
+      if (!response.ok) {
+        const errorData = await response
+          .json()
+          .catch(() => ({ error: "Unknown error" }));
+        throw new Error(errorData.error || `HTTP ${response.status}`);
+      }
 
-    return response.json();
-  };
+      return response.json();
+    },
+    []
+  );
 
   const value: AppContextType = {
     // App state

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -7,6 +7,9 @@ import React, {
   ReactNode,
 } from "react";
 
+import { apiCall } from "../utils/api";
+import { clearStoredState, useStoredState } from "../hooks/useStoredState";
+
 import type {
   Analytics,
   Bar,
@@ -57,7 +60,7 @@ interface AppContextType {
   categories: Category[];
 
   // UI states
-  editingDrink: Drink | {} | null;
+  editingDrink: Drink | "new" | null;
   viewingRecipe: Drink | null;
   showPassword: boolean;
   currentTab: Tab;
@@ -75,7 +78,7 @@ interface AppContextType {
   setOrders: React.Dispatch<React.SetStateAction<Order[]>>;
   setAnalytics: React.Dispatch<React.SetStateAction<Analytics | null>>;
   setCategories: React.Dispatch<React.SetStateAction<Category[]>>;
-  setEditingDrink: (drink: Drink | {} | null) => void;
+  setEditingDrink: (drink: Drink | "new" | null) => void;
   setViewingRecipe: (drink: Drink | null) => void;
   setShowPassword: (show: boolean) => void;
   setCurrentTab: (tab: Tab) => void;
@@ -94,95 +97,23 @@ export const useApp = () => {
   return context;
 };
 
-const API_BASE = "/api";
-
-// Everything this app saves in the browser starts with this, so signing out
-// can clear its own things without touching anything else on the site.
-export const STORAGE_PREFIX = "homeBarSystem_";
-
-const STORAGE_KEYS = {
-  userType: "homeBarSystem_userType",
-  currentBar: "homeBarSystem_currentBar",
-  customerName: "homeBarSystem_customerName",
-  language: "homeBarSystem_language",
-  currentTab: "homeBarSystem_currentTab",
-};
-
 export const AppProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  // Initialize state from localStorage if available
-  const loadFromStorage = <T,>(key: string, defaultValue: T): T => {
-    const storedValue = localStorage.getItem(key);
-    return storedValue ? JSON.parse(storedValue) : defaultValue;
-  };
-
-  const saveToStorage = <T,>(key: string, value: T) => {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch (error) {
-      console.error(`Failed to save ${key} to localStorage`, error);
-    }
-  };
-
-  // App state with initial values from localStorage
-  const [userType, setUserTypeState] = useState<UserType | null>(
-    () => loadFromStorage(STORAGE_KEYS.userType, null)
+  const [userType, setUserType] = useStoredState<UserType | null>(
+    "userType",
+    null
   );
-
-  const [currentBar, setCurrentBarState] = useState<Bar | null>(() =>
-    loadFromStorage(STORAGE_KEYS.currentBar, null)
+  const [currentBar, setCurrentBar] = useStoredState<Bar | null>(
+    "currentBar",
+    null
   );
-
-  const [customerName, setCustomerNameState] = useState(() =>
-    loadFromStorage(STORAGE_KEYS.customerName, "")
+  const [customerName, setCustomerName] = useStoredState("customerName", "");
+  const [language, setLanguage] = useStoredState<Language>("language", "en");
+  const [currentTab, setCurrentTab] = useStoredState<Tab>(
+    "currentTab",
+    "orders"
   );
-
-  const [language, setLanguageState] = useState<Language>(() =>
-    loadFromStorage(STORAGE_KEYS.language, "en")
-  );
-
-  const [currentTab, setCurrentTabState] = useState<Tab>(() =>
-    loadFromStorage(STORAGE_KEYS.currentTab, "orders")
-  );
-
-  // Wrapper functions that save to storage
-  const setUserType = (type: UserType | null) => {
-    setUserTypeState(type);
-    if (type === null) {
-      localStorage.removeItem(STORAGE_KEYS.userType);
-    } else {
-      saveToStorage(STORAGE_KEYS.userType, type);
-    }
-  };
-
-  const setCurrentBar = (bar: Bar | null) => {
-    setCurrentBarState(bar);
-    if (bar === null) {
-      localStorage.removeItem(STORAGE_KEYS.currentBar);
-    } else {
-      saveToStorage(STORAGE_KEYS.currentBar, bar);
-    }
-  };
-
-  const setCustomerName = (name: string) => {
-    setCustomerNameState(name);
-    if (name === "") {
-      localStorage.removeItem(STORAGE_KEYS.customerName);
-    } else {
-      saveToStorage(STORAGE_KEYS.customerName, name);
-    }
-  };
-
-  const setLanguage = (lang: Language) => {
-    setLanguageState(lang);
-    saveToStorage(STORAGE_KEYS.language, lang);
-  };
-
-  const setCurrentTab = (tab: Tab) => {
-    setCurrentTabState(tab);
-    saveToStorage(STORAGE_KEYS.currentTab, tab);
-  };
 
   // Loading and error states
   const [loading, setLoading] = useState(false);
@@ -204,12 +135,14 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   const [categories, setCategories] = useState<Category[]>([]);
 
   // UI states
-  const [editingDrink, setEditingDrink] = useState<Drink | {} | null>(null);
+  const [editingDrink, setEditingDrink] = useState<Drink | "new" | null>(
+    null
+  );
   const [viewingRecipe, setViewingRecipe] = useState<Drink | null>(null);
   const [showPassword, setShowPassword] = useState(false);
 
-  // Clear all data function
-  const clearAllData = () => {
+  /** Puts everything back as it was before anyone signed in. */
+  const clearAllData = useCallback(() => {
     setUserType(null);
     setCurrentBar(null);
     setCustomerName("");
@@ -223,10 +156,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     });
     setLoginForm({ password: "", name: "" });
 
-    Object.keys(localStorage)
-      .filter((key) => key.startsWith(STORAGE_PREFIX))
-      .forEach((key) => localStorage.removeItem(key));
-  };
+    clearStoredState();
+  }, [setUserType, setCurrentBar, setCustomerName, setLanguage, setCurrentTab]);
 
   // Session validation effect
   useEffect(() => {
@@ -270,32 +201,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     };
 
     validateSession();
-  }, [userType, currentBar, customerName]);
-
-  // Talks to the API. It keeps the same identity for the life of the app,
-  // because anything that reloads when this changes would otherwise reload on
-  // every single render.
-  const apiCall = useCallback(
-    async (endpoint: string, options: RequestInit = {}) => {
-      const response = await fetch(`${API_BASE}${endpoint}`, {
-        headers: {
-          "Content-Type": "application/json",
-          ...options.headers,
-        },
-        ...options,
-      });
-
-      if (!response.ok) {
-        const errorData = await response
-          .json()
-          .catch(() => ({ error: "Unknown error" }));
-        throw new Error(errorData.error || `HTTP ${response.status}`);
-      }
-
-      return response.json();
-    },
-    []
-  );
+  }, [userType, currentBar, customerName, clearAllData]);
 
   const value: AppContextType = {
     // App state

--- a/frontend/src/hooks/useGuestMenu.ts
+++ b/frontend/src/hooks/useGuestMenu.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useApp } from "../context/AppContext";
+import type { Drink } from "../types";
+
+/** The order the bar likes its spirits listed in. Anything else goes last. */
+const SPIRIT_ORDER = [
+  "Vodka",
+  "Gin",
+  "Rum",
+  "Tequila",
+  "Whisky/Whiskey",
+  "Brandy/Cognac",
+  "Liqueur",
+  "Non-alcoholic",
+  "Other",
+];
+
+export type MenuFilter =
+  | { type: "all" }
+  | { type: "category"; value: string }
+  | { type: "spirit"; value: string };
+
+const byTitle = (a: Drink, b: Drink): number => a.title.localeCompare(b.title);
+
+/** Sorts drinks into named piles, each pile in alphabetical order. */
+function groupBy(drinks: Drink[], nameOf: (drink: Drink) => string) {
+  const groups: Record<string, Drink[]> = {};
+
+  for (const drink of drinks) {
+    const name = nameOf(drink);
+    (groups[name] ??= []).push(drink);
+  }
+
+  for (const pile of Object.values(groups)) pile.sort(byTitle);
+
+  return groups;
+}
+
+/**
+ * Everything the guest's menu needs: what is on it, how it is grouped, and
+ * which part of it they are looking at.
+ */
+export function useGuestMenu() {
+  const { currentBar, customerName, drinks, setDrinks, setOrders, apiCall } =
+    useApp();
+
+  const [favourites, setFavourites] = useState<Drink[]>([]);
+  const [filter, setFilter] = useState<MenuFilter>({ type: "all" });
+
+  const barId = currentBar?.id;
+  const guest = customerName ? encodeURIComponent(customerName) : "";
+
+  const refreshDrinks = useCallback(async () => {
+    if (!barId || !guest) return;
+    try {
+      // The guest's own list, so their favourites come back marked.
+      setDrinks(await apiCall(`/drinks/bar/${barId}/guest/${guest}`));
+    } catch (err) {
+      console.error("Could not load the drinks:", err);
+    }
+  }, [barId, guest, apiCall, setDrinks]);
+
+  const refreshFavourites = useCallback(async () => {
+    if (!barId || !guest) return;
+    try {
+      const data: Drink[] = await apiCall(
+        `/drinks/bar/${barId}/favourites/${guest}`
+      );
+      setFavourites([...data].sort(byTitle));
+    } catch (err) {
+      console.error("Could not load the favourites:", err);
+    }
+  }, [barId, guest, apiCall]);
+
+  const refreshOrders = useCallback(async () => {
+    if (!barId) return;
+    try {
+      setOrders(await apiCall(`/orders/bar/${barId}`));
+    } catch (err) {
+      console.error("Could not load the orders:", err);
+    }
+  }, [barId, apiCall, setOrders]);
+
+  useEffect(() => {
+    refreshDrinks();
+    refreshFavourites();
+    refreshOrders();
+  }, [refreshDrinks, refreshFavourites, refreshOrders]);
+
+  const inStock = useMemo(() => drinks.filter((d) => d.in_stock), [drinks]);
+
+  const bySpirit = useMemo(
+    () => groupBy(inStock, (d) => d.base_spirit || "Other"),
+    [inStock]
+  );
+
+  const byCategory = useMemo(
+    () => groupBy(inStock, (d) => d.category_name || "Uncategorized"),
+    [inStock]
+  );
+
+  const spirits = SPIRIT_ORDER.filter((s) => bySpirit[s]?.length);
+  const categories = Object.keys(byCategory).sort();
+
+  // "All" shows every group in turn rather than one flat list.
+  const filtered =
+    filter.type === "category"
+      ? (byCategory[filter.value] ?? [])
+      : filter.type === "spirit"
+        ? (bySpirit[filter.value] ?? [])
+        : [];
+
+  return {
+    inStock,
+    favourites,
+    bySpirit,
+    byCategory,
+    spirits,
+    categories,
+    filter,
+    setFilter,
+    filtered,
+    refreshDrinks,
+    refreshFavourites,
+    refreshOrders,
+  };
+}

--- a/frontend/src/hooks/useGuestMenu.ts
+++ b/frontend/src/hooks/useGuestMenu.ts
@@ -1,19 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useApp } from "../context/AppContext";
 import type { Drink } from "../types";
-
-/** The order the bar likes its spirits listed in. Anything else goes last. */
-const SPIRIT_ORDER = [
-  "Vodka",
-  "Gin",
-  "Rum",
-  "Tequila",
-  "Whisky/Whiskey",
-  "Brandy/Cognac",
-  "Liqueur",
-  "Non-alcoholic",
-  "Other",
-];
+import { BASE_SPIRITS } from "../utils/spirits";
 
 export type MenuFilter =
   | { type: "all" }
@@ -99,7 +87,7 @@ export function useGuestMenu() {
     [inStock]
   );
 
-  const spirits = SPIRIT_ORDER.filter((s) => bySpirit[s]?.length);
+  const spirits = BASE_SPIRITS.filter((s) => bySpirit[s]?.length);
   const categories = Object.keys(byCategory).sort();
 
   // "All" shows every group in turn rather than one flat list.

--- a/frontend/src/hooks/useStoredState.ts
+++ b/frontend/src/hooks/useStoredState.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+
+// Everything this app saves in the browser starts with this, so signing out
+// can clear its own things without touching anything else on the site.
+export const STORAGE_PREFIX = "homeBarSystem_";
+
+/** Blank values are removed rather than saved, so nothing is left behind. */
+const isBlank = (value: unknown): boolean => value === null || value === "";
+
+function read<T>(key: string, fallback: T): T {
+  const saved = localStorage.getItem(key);
+  if (saved === null) return fallback;
+
+  try {
+    return JSON.parse(saved) as T;
+  } catch {
+    // Something else wrote here, or it was cut short. Start fresh rather
+    // than leave the page blank.
+    return fallback;
+  }
+}
+
+/**
+ * State that survives a refresh. Behaves like useState, and writes to the
+ * browser's own storage as it goes.
+ */
+export function useStoredState<T>(
+  name: string,
+  fallback: T
+): [T, (value: T) => void] {
+  const key = `${STORAGE_PREFIX}${name}`;
+  const [value, setValue] = useState<T>(() => read(key, fallback));
+
+  const save = useCallback(
+    (next: T) => {
+      setValue(next);
+      try {
+        if (isBlank(next)) localStorage.removeItem(key);
+        else localStorage.setItem(key, JSON.stringify(next));
+      } catch (error) {
+        console.error(`Could not save ${key}`, error);
+      }
+    },
+    [key]
+  );
+
+  return [value, save];
+}
+
+/** Forgets everything this app saved, and nothing else. */
+export function clearStoredState(): void {
+  Object.keys(localStorage)
+    .filter((key) => key.startsWith(STORAGE_PREFIX))
+    .forEach((key) => localStorage.removeItem(key));
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,31 @@
+const API_BASE = "/api";
+
+/**
+ * Talks to the API. Anything other than a success is turned into an error
+ * carrying the message the server sent, which is what the pages show.
+ *
+ * A plain function rather than something built per render, so anything that
+ * reloads when it changes never has to.
+ */
+export async function apiCall(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<any> {
+  const response = await fetch(`${API_BASE}${endpoint}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const problem = await response
+      .json()
+      .catch(() => ({ error: `HTTP ${response.status}` }));
+
+    throw new Error(problem.error || `HTTP ${response.status}`);
+  }
+
+  return response.json();
+}

--- a/frontend/src/utils/orderStatus.tsx
+++ b/frontend/src/utils/orderStatus.tsx
@@ -1,0 +1,39 @@
+import { Check, CheckCircle, Clock, Coffee, XCircle } from "lucide-react";
+import type { OrderStatus } from "../types";
+
+// How an order looks at each step. Both the guest's page and the bartender's
+// queue read from here, so an order never looks like two different things.
+
+const ICONS: Record<OrderStatus, React.ReactNode> = {
+  new: <Clock className="w-5 h-5 text-yellow-500" />,
+  accepted: <CheckCircle className="w-5 h-5 text-blue-500" />,
+  rejected: <XCircle className="w-5 h-5 text-red-500" />,
+  ready: <Coffee className="w-5 h-5 text-green-500" />,
+  processed: <Check className="w-5 h-5 text-gray-500" />,
+};
+
+const CARD: Record<OrderStatus, string> = {
+  new: "bg-yellow-50 border-yellow-200",
+  accepted: "bg-blue-50 border-blue-200",
+  rejected: "bg-red-50 border-red-200",
+  ready: "bg-green-50 border-green-200",
+  processed: "bg-gray-50 border-gray-200",
+};
+
+const TEXT: Record<OrderStatus, string> = {
+  new: "text-yellow-800",
+  accepted: "text-blue-800",
+  rejected: "text-red-800",
+  ready: "text-green-800",
+  processed: "text-gray-800",
+};
+
+export const statusIcon = (status: OrderStatus): React.ReactNode =>
+  ICONS[status];
+
+/** Background and border, for a card sitting among others. */
+export const statusCard = (status: OrderStatus): string => CARD[status];
+
+/** The same, plus a matching text colour, for a card on its own. */
+export const statusCardWithText = (status: OrderStatus): string =>
+  `${CARD[status]} ${TEXT[status]}`;

--- a/frontend/src/utils/spirits.ts
+++ b/frontend/src/utils/spirits.ts
@@ -1,0 +1,15 @@
+/**
+ * What a drink can be based on, in the order the bar likes them listed.
+ * The guest's menu groups by these, and the drink form offers them.
+ */
+export const BASE_SPIRITS = [
+  "Vodka",
+  "Gin",
+  "Rum",
+  "Tequila",
+  "Whisky/Whiskey",
+  "Brandy/Cognac",
+  "Liqueur",
+  "Non-alcoholic",
+  "Other",
+];


### PR DESCRIPTION
Closes #30. Two commits — the guest's page, then the bartender's pages and the shared state.

| File | Before | After |
| --- | ---: | ---: |
| `CustomerInterface.tsx` | 735 | **311** |
| `DrinkForm.tsx` | 496 | **281** |
| `AnalyticsTab.tsx` | 366 | **209** |
| `AppContext.tsx` | 344 | **256** |

New pieces: `useGuestMenu`, `useStoredState`, `utils/api`, `utils/orderStatus`, `utils/spirits`, `customer/{DrinkGrid,MenuFilters,OrderPlacedModal}`, `analytics/{StatCard,RankedBars,StatList}`, `drinkForm/DrinkImageField`.

## Duplication removed

- The same `<DrinkCard>` with the same seven props appeared **five times** in the guest's page.
- `getStatusIcon`/`getStatusColor` were written out in both `CustomerInterface` and `OrdersTab`. Now `Record<OrderStatus, …>`, so a missing status is a build error rather than a silent `default:`. `OrderStatusCard` imports them instead of taking them as props.
- Adding and changing a drink sent an identical body to two endpoints.
- Four stat cards, two bar charts and two stat lists in the reports were each written out in full.
- The five saved settings each had their own set-and-persist wrapper.
- The base spirits list existed in both the guest's menu and the drink form.

## Real fixes found on the way

**`apiCall` was rebuilt every render.** Anything listing it as a dependency re-ran constantly — `LiveUpdatesContext` does, so the live-updates connection was **torn down and reopened every time an order came in**. It is a plain module function now, so it is stable for free. Without this the new hook would have looped, which is how I noticed.

**`RandomDrinkModal.tsx` was dead code** — the surprise-me modal exists as a component and was never imported; the page carried its own copy of the same markup.

**"Avg orders per day" was `totalOrders / 7`** — a made-up divisor. The server sends a real average, but over the report's window, so the row now names the window rather than sitting unlabelled under "All Time Stats". Flagging this one: it is the only user-visible number that changes.

**A corrupt saved setting white-screened the app.** `JSON.parse` on stored state had no guard; `useStoredState` falls back to the default.

**`editingDrink` was `Drink | {} | null`**, where `{}` meant "adding one". Now `"new"`, which removes ten `"field" in drink` checks from the form.

## Checked

Typecheck and build clean. Lint warnings **25 → 16**, all pre-existing ones (`#37` clears the rest).

Ran the built image against a copy of the production database and drove both sides in a headless browser.

Guest page: 18 sections, 302 cards, sidebar intact; filtering by Gin gives 1 section and 31 cards; surprise-me opens, "try another" gives a different drink, Escape closes; **every endpoint fetched exactly once**.

Bartender: reports render with the right figures and 5 chart bars; editing a drink fills the form correctly (title, spirit, category, image, recipe editor, crop button, checkbox); Escape closes it; "add drink" opens blank with the right heading. No console errors on either.

One deliberate difference: the file picker's `accept` list is now `image/*`, which the old explicit list already ended with.