### PR TITLE
Clear the last lint warnings and make them errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Lint frontend
         working-directory: frontend
-        run: npx eslint src
+        run: npm run lint
 
       - name: Build frontend
         working-directory: frontend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,12 @@ Test the `staging` image against a copy of the real data before releasing.
 
 ```sh
 cd backend  && npm test && npm run lint && npm run typecheck
-cd frontend && npx eslint src && npm run build
+cd frontend && npm run lint && npm run build
 ```
+
+Both linters fail on a warning, so anything new has to be dealt with rather
+than left to pile up. `any` is an error in both halves: if a shape is not
+known, add it to `shared/types.d.ts`.
 
 `docker compose -f compose.yaml -f compose.dev.yaml up --build` builds and runs
 the real image from a checkout.

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -24,6 +24,8 @@ export default tseslint.config(
         "error",
         { fixStyle: "inline-type-imports" },
       ],
+      // Both halves hold to this, so neither drifts back to untyped payloads.
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
   {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src tests"
+    "lint": "eslint src tests --max-warnings 0"
   },
   "dependencies": {
     "bcrypt": "6.0.0",

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import express, { type Router } from "express";
 import bcrypt from "bcrypt";
 
-import type { UserType } from "../../../shared/types.js";
+import type { SignedIn, UserType } from "../../../shared/types.js";
 import { HttpError, requireId, requireText, route } from "../http.js";
 import { findBar, publicBar, type BarRow, type Db } from "../db/queries.js";
 
@@ -15,7 +15,7 @@ const PASSWORD_FIELD = {
  * The reply to a sign-in. The whole bar goes back, so the pages never have to
  * piece one together from loose fields and lose its settings doing it.
  */
-function signedInAs(bar: BarRow, userType: UserType) {
+function signedInAs(bar: BarRow, userType: UserType): SignedIn {
   return { success: true, userType, bar: publicBar(bar) };
 }
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -2,7 +2,12 @@ import express, { type Router } from "express";
 import bcrypt from "bcrypt";
 import QRCode from "qrcode";
 
-import type { Bar, Language, Order } from "../../../shared/types.js";
+import type {
+  Bar,
+  BarQrCode,
+  Language,
+  Order,
+} from "../../../shared/types.js";
 import {
   HttpError,
   idParam,
@@ -262,7 +267,7 @@ export default function createBarRoutes({
       const baseUrl = publicUrl || `${req.protocol}://${req.get("host")}`;
       const url = `${baseUrl}/bar/${barId}?token=${guestToken(barId)}`;
 
-      res.json({
+      const code = {
         barId: bar.id,
         barName: bar.name,
         url,
@@ -271,7 +276,9 @@ export default function createBarRoutes({
           margin: 2,
           color: { dark: "#1e40af", light: "#ffffff" },
         }),
-      });
+      } satisfies BarQrCode;
+
+      res.json(code);
     })
   );
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -38,11 +38,8 @@ export default [
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
       "no-unused-vars": "off",
-      // Warnings for now: linting had never actually run, and these two flag
-      // existing code that issues #27 and #31 are already set up to fix.
-      // Turn them back into errors once those land.
-      "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-empty-object-type": "warn",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-empty-object-type": "error",
     },
   },
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
     "@types/qrcode": "^1.5.5",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,8 @@ import DrinkForm from "./components/DrinkForm";
 import RecipeView from "./components/RecipeView";
 import ErrorDisplay from "./components/ErrorDisplay";
 import QRRedirect from "./components/QRRedirect";
-import { AppProvider, useApp } from "./context/AppContext";
+import { AppProvider } from "./context/AppContext";
+import { useApp } from "./hooks/useApp";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesContext";
 import PastOrdersPage from "./pages/PastOrdersPage";
 

--- a/frontend/src/components/AnalyticsTab.tsx
+++ b/frontend/src/components/AnalyticsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from "react";
 import { BarChart3, TrendingUp, Coffee, Clock, Star } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { OrderStatus } from "../types";
 import { useTranslation } from "../utils/translations";
 import StatCard from "./analytics/StatCard";

--- a/frontend/src/components/BarCreator.tsx
+++ b/frontend/src/components/BarCreator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 
 interface BarCreatorProps {
@@ -33,7 +34,7 @@ const BarCreator: React.FC<BarCreatorProps> = ({ onBack, onSuccess }) => {
     setError(null);
 
     try {
-      const data = await apiCall("/bars", {
+      const data = await apiCall<Bar>("/bars", {
         method: "POST",
         body: JSON.stringify({
           name: barForm.name,

--- a/frontend/src/components/BarSelector.tsx
+++ b/frontend/src/components/BarSelector.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { RefreshCw, Plus } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 
@@ -19,22 +19,21 @@ const BarSelector: React.FC<BarSelectorProps> = ({
   const [availableBars, setAvailableBars] = useState<Bar[]>([]);
   const [loadingBars, setLoadingBars] = useState(false);
 
-  const fetchBars = async () => {
+  const fetchBars = useCallback(async () => {
     setLoadingBars(true);
     try {
-      const data = await apiCall("/bars");
-      setAvailableBars(data);
+      setAvailableBars(await apiCall<Bar[]>("/bars"));
     } catch (err) {
-      console.error("Error fetching bars:", err);
+      console.error("Could not load the bars:", err);
       setAvailableBars([]);
     } finally {
       setLoadingBars(false);
     }
-  };
+  }, [apiCall]);
 
   useEffect(() => {
     fetchBars();
-  }, []);
+  }, [fetchBars]);
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/BartenderDashboard.tsx
+++ b/frontend/src/components/BartenderDashboard.tsx
@@ -1,9 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Plus, QrCode } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type {
+  Analytics,
+  BarQrCode,
+  Drink,
+  Order,
+} from "../types";
 import { useTranslation } from "../utils/translations";
 import { useSessionManager } from "../hooks/useSessionManager";
-import { useLiveUpdates } from "../context/LiveUpdatesContext";
+import { useLiveUpdates } from "../hooks/useLiveUpdates";
 import { ConnectionLost } from "./ConnectionLost";
 import OrdersTab from "./OrdersTab";
 import MenuTab from "./MenuTab";
@@ -44,36 +50,34 @@ const BartenderDashboard: React.FC = () => {
   } | null>(null);
   const [qrLoading, setQrLoading] = useState(false);
 
-  // Data fetching functions
-  const fetchDrinks = async () => {
-    if (!currentBar) return;
-    try {
-      const data = await apiCall(`/drinks/bar/${currentBar.id}`);
-      setDrinks(data);
-    } catch (err) {
-      console.error("Error fetching drinks:", err);
-    }
-  };
+  const barId = currentBar?.id;
 
-  const fetchOrders = async () => {
-    if (!currentBar) return;
+  const fetchDrinks = useCallback(async () => {
+    if (!barId) return;
     try {
-      const data = await apiCall(`/orders/bar/${currentBar.id}`);
-      setOrders(data);
+      setDrinks(await apiCall<Drink[]>(`/drinks/bar/${barId}`));
     } catch (err) {
-      console.error("Error fetching orders:", err);
+      console.error("Could not load the drinks:", err);
     }
-  };
+  }, [barId, apiCall, setDrinks]);
 
-  const fetchAnalytics = async () => {
-    if (!currentBar) return;
+  const fetchOrders = useCallback(async () => {
+    if (!barId) return;
     try {
-      const data = await apiCall(`/orders/bar/${currentBar.id}/analytics`);
-      setAnalytics(data);
+      setOrders(await apiCall<Order[]>(`/orders/bar/${barId}`));
     } catch (err) {
-      console.error("Error fetching analytics:", err);
+      console.error("Could not load the orders:", err);
     }
-  };
+  }, [barId, apiCall, setOrders]);
+
+  const fetchAnalytics = useCallback(async () => {
+    if (!barId) return;
+    try {
+      setAnalytics(await apiCall<Analytics>(`/orders/bar/${barId}/analytics`));
+    } catch (err) {
+      console.error("Could not load the reports:", err);
+    }
+  }, [barId, apiCall, setAnalytics]);
 
   // Generate QR code
   const handleGenerateQR = async () => {
@@ -81,7 +85,7 @@ const BartenderDashboard: React.FC = () => {
     
     setQrLoading(true);
     try {
-      const data = await apiCall(`/bars/${currentBar.id}/qrcode`);
+      const data = await apiCall<BarQrCode>(`/bars/${currentBar.id}/qrcode`);
       setQrData(data);
       setShowQRModal(true);
     } catch (err) {
@@ -91,14 +95,11 @@ const BartenderDashboard: React.FC = () => {
     }
   };
 
-  // Initial data fetch
   useEffect(() => {
-    if (currentBar) {
-      fetchDrinks();
-      fetchOrders();
-      fetchAnalytics();
-    }
-  }, [currentBar]);
+    fetchDrinks();
+    fetchOrders();
+    fetchAnalytics();
+  }, [fetchDrinks, fetchOrders, fetchAnalytics]);
 
   const pendingOrders = orders.filter((order) =>
     ["new", "accepted", "ready"].includes(order.status)

--- a/frontend/src/components/CategoriesTab.tsx
+++ b/frontend/src/components/CategoriesTab.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Plus, Edit3, Trash2, Tag } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Category } from "../types";
 import { useTranslation } from "../utils/translations";
 
@@ -23,23 +23,23 @@ const CategoriesTab: React.FC = () => {
   const [newCategoryName, setNewCategoryName] = useState("");
   const [showCreateForm, setShowCreateForm] = useState(false);
 
-  // Fetch categories when component mounts
-  useEffect(() => {
-    if (currentBar) {
-      fetchCategories();
-    }
-  }, [currentBar]);
+  const barId = currentBar?.id;
 
-  const fetchCategories = async () => {
-    if (!currentBar) return;
+  const fetchCategories = useCallback(async () => {
+    if (!barId) return;
     try {
-      const data = await apiCall(`/categories/bar/${currentBar.id}`);
-      setCategories(data);
+      setCategories(await apiCall<Category[]>(`/categories/bar/${barId}`));
     } catch (err) {
-      console.error("Error fetching categories:", err);
-      setError(err instanceof Error ? err.message : "Failed to fetch categories");
+      console.error("Could not load the categories:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch categories"
+      );
     }
-  };
+  }, [barId, apiCall, setCategories, setError]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
 
   const handleCreateCategory = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,7 +48,7 @@ const CategoriesTab: React.FC = () => {
 
     setLoading(true);
     try {
-      const newCategory = await apiCall("/categories", {
+      const newCategory = await apiCall<Category>("/categories", {
         method: "POST",
         body: JSON.stringify({
           barId: currentBar.id,
@@ -71,7 +71,7 @@ const CategoriesTab: React.FC = () => {
 
     setLoading(true);
     try {
-      const updatedCategory = await apiCall(`/categories/${category.id}`, {
+      const updatedCategory = await apiCall<Category>(`/categories/${category.id}`, {
         method: "PUT",
         body: JSON.stringify({
           barId: currentBar.id,

--- a/frontend/src/components/ConnectionLost.tsx
+++ b/frontend/src/components/ConnectionLost.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { WifiOff, RefreshCw } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import { translations } from "../utils/translations";
 
 interface ConnectionLostProps {

--- a/frontend/src/components/CustomerInterface.tsx
+++ b/frontend/src/components/CustomerInterface.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Coffee } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { useSessionManager } from "../hooks/useSessionManager";
 import { useGuestMenu } from "../hooks/useGuestMenu";
-import { useLiveUpdates } from "../context/LiveUpdatesContext";
+import { useLiveUpdates } from "../hooks/useLiveUpdates";
 import { ConnectionLost } from "./ConnectionLost";
 import OrderStatusCard from "./OrderStatusCard";
 import RandomDrinkModal from "./RandomDrinkModal";

--- a/frontend/src/components/DrinkCard.tsx
+++ b/frontend/src/components/DrinkCard.tsx
@@ -93,10 +93,10 @@ const DrinkCard: React.FC<DrinkCardProps> = ({
       </div>
       <div
         className="prose prose-sm text-gray-800 max-w-none"
-        style={{
-          // Force readable text color for markdown output
-          ["--color-fg-default" as any]: "#222",
-        }}
+        style={
+          // Keeps the markdown readable on a light background.
+          { "--color-fg-default": "#222" } as React.CSSProperties
+        }
       >
         {/* Rendered markdown content here */}
       </div>

--- a/frontend/src/components/DrinkForm.tsx
+++ b/frontend/src/components/DrinkForm.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { X } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { BASE_SPIRITS } from "../utils/spirits";

--- a/frontend/src/components/ErrorDisplay.tsx
+++ b/frontend/src/components/ErrorDisplay.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import { useTranslation } from "../utils/translations";
 
 interface ErrorDisplayProps {

--- a/frontend/src/components/ImageCropper.tsx
+++ b/frontend/src/components/ImageCropper.tsx
@@ -21,11 +21,14 @@ const ImageCropper: React.FC<ImageCropperProps> = ({
   const [crop, setCrop] = useState(initialCrop);
   const [zoom, setZoom] = useState(initialZoom);
 
-  // Sync state with props when they change
+  // Taken apart, because the caller passes a fresh object every render and
+  // watching that would reset the crop while it is being dragged.
+  const { x: startX, y: startY } = initialCrop;
+
   useEffect(() => {
-    setCrop(initialCrop);
+    setCrop({ x: startX, y: startY });
     setZoom(initialZoom);
-  }, [initialCrop.x, initialCrop.y, initialZoom]);
+  }, [startX, startY, initialZoom]);
 
   const onCropComplete = useCallback((_croppedArea: Area, _croppedAreaPixels: Area) => {
     // Crop area is tracked internally by react-easy-crop

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 import BarSelector from "./BarSelector";

--- a/frontend/src/components/LazyMDEditor.tsx
+++ b/frontend/src/components/LazyMDEditor.tsx
@@ -11,7 +11,7 @@ interface LazyMDEditorProps {
   "data-color-mode"?: "light" | "dark";
   textareaProps?: {
     placeholder?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Eye, EyeOff, LogIn } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Bar } from "../types";
 import { useTranslation } from "../utils/translations";
 
@@ -70,14 +70,12 @@ const LoginForm: React.FC<LoginFormProps> = ({
     try {
       const endpoint =
         userType === "bartender" ? "/auth/bartender" : "/auth/guest";
-      const body: any = {
-        barId: barId,
+      const body = {
+        barId,
         password: loginForm.password,
+        // Guests give their name; the bartender does not.
+        ...(userType === "guest" && { customerName: loginForm.name }),
       };
-
-      if (userType === "guest") {
-        body.customerName = loginForm.name;
-      }
 
       await apiCall(endpoint, {
         method: "POST",

--- a/frontend/src/components/MenuTab.tsx
+++ b/frontend/src/components/MenuTab.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Plus, Edit3, Trash2, Package, PackageX, Eye } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import { useTranslation } from "../utils/translations";
 import { LazyMarkdownViewer } from "./LazyMDEditor";
 

--- a/frontend/src/components/OrdersTab.tsx
+++ b/frontend/src/components/OrdersTab.tsx
@@ -8,7 +8,8 @@ import {
   Coffee,
   User,
 } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type { OrderStatus } from "../types";
 import { statusCard, statusIcon } from "../utils/orderStatus";
 import { useTranslation } from "../utils/translations";
 
@@ -33,7 +34,10 @@ const OrdersTab: React.FC = () => {
     setShowRecipes((prev) => !prev);
   };
 
-  const handleUpdateOrderStatus = async (orderId: number, status: string) => {
+  const handleUpdateOrderStatus = async (
+    orderId: number,
+    status: OrderStatus
+  ) => {
     setLoading(true);
     try {
       await apiCall(`/orders/${orderId}/status`, {
@@ -50,7 +54,7 @@ const OrdersTab: React.FC = () => {
           order.id === orderId
             ? {
                 ...order,
-                status: status as any,
+                status,
                 updated_at: new Date().toISOString(),
               }
             : order

--- a/frontend/src/components/PastOrders.tsx
+++ b/frontend/src/components/PastOrders.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Eye, Package } from "lucide-react";
-import type { Drink } from "../types";
+import type { Drink, Order } from "../types";
 import { TranslationKeys } from "../utils/translations";
 
 interface PastOrdersProps {
-  orders: any[];
+  orders: Order[];
   drinks: Drink[];
   customerName: string;
-  customerOrder: any;
+  customerOrder: Order | undefined;
   loading: boolean;
   t: (key: TranslationKeys) => string;
   handlePlaceOrder: (drink: Drink) => void;

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type { Bar, SignedIn } from "../types";
 import LoginForm from "./LoginForm";
 import { ACTIVITY_KEY } from "../hooks/useSessionManager";
 
@@ -34,7 +35,7 @@ const QRRedirect: React.FC = () => {
 
       try {
         setLoading(true);
-        const bar = await apiCall(`/bars/${id}`);
+        const bar = await apiCall<Bar>(`/bars/${id}`);
         
         // Set the bar and language in context
         setCurrentBar(bar);
@@ -76,13 +77,13 @@ const QRRedirect: React.FC = () => {
     setError(null);
 
     try {
-      const response = await apiCall(`/bars/${id}/guest-token-login`, {
-        method: "POST",
-        body: JSON.stringify({
-          token,
-          customerName: guestName.trim(),
-        }),
-      });
+      const response = await apiCall<SignedIn>(
+        `/bars/${id}/guest-token-login`,
+        {
+          method: "POST",
+          body: JSON.stringify({ token, customerName: guestName.trim() }),
+        }
+      );
 
       // Update app context with authentication info
       setCustomerName(guestName.trim());

--- a/frontend/src/components/RecipeView.tsx
+++ b/frontend/src/components/RecipeView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { X, Clock, Users, ChefHat } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { LazyMarkdownViewer } from "./LazyMDEditor";
@@ -155,10 +155,10 @@ const RecipeView: React.FC<RecipeViewProps> = ({ drink, onClose }) => {
           <div className="prose prose-sm text-gray-800 max-w-none">
             <LazyMarkdownViewer
               source={drink.recipe ?? ""}
-              style={{
-                // Force readable text color for markdown output
-                ["--color-fg-default" as any]: "#222",
-              }}
+              style={
+                // Keeps the markdown readable on a light background.
+                { "--color-fg-default": "#222" } as React.CSSProperties
+              }
             />
           </div>
         </div>

--- a/frontend/src/components/SettingsTab.tsx
+++ b/frontend/src/components/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Settings, Save } from "lucide-react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type { Bar } from "../types";
 
 const SettingsTab: React.FC = () => {
   const {
@@ -24,7 +25,7 @@ const SettingsTab: React.FC = () => {
     setLoading(true);
     
     try {
-      const updatedBar = await apiCall(`/bars/${currentBar.id}`, {
+      const updatedBar = await apiCall<Bar>(`/bars/${currentBar.id}`, {
         method: "PUT",
         body: JSON.stringify({
           skipApproval,

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,12 +1,6 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-  ReactNode,
-} from "react";
+import React, { useCallback, useEffect, useState, ReactNode } from "react";
 
+import { AppContext, type AppContextType, type Tab } from "../hooks/useApp";
 import { apiCall } from "../utils/api";
 import { clearStoredState, useStoredState } from "../hooks/useStoredState";
 
@@ -19,83 +13,6 @@ import type {
   Order,
   UserType,
 } from "../types";
-
-/** The bartender's tabs, in the order they appear. */
-export type Tab =
-  | "orders"
-  | "menu"
-  | "analytics"
-  | "categories"
-  | "settings";
-
-/** The two sign-in forms hold the same handful of fields throughout. */
-type BarForm = {
-  name: string;
-  bartenderPassword: string;
-  guestPassword: string;
-  language: Language;
-};
-
-type LoginForm = { password: string; name: string };
-
-interface AppContextType {
-  // App state
-  userType: UserType | null;
-  currentBar: Bar | null;
-  customerName: string;
-  language: Language;
-
-  // Loading and error states
-  loading: boolean;
-  error: string | null;
-
-  // Form states
-  barForm: BarForm;
-  loginForm: LoginForm;
-
-  // Data states
-  drinks: Drink[];
-  orders: Order[];
-  analytics: Analytics | null;
-  categories: Category[];
-
-  // UI states
-  editingDrink: Drink | "new" | null;
-  viewingRecipe: Drink | null;
-  showPassword: boolean;
-  currentTab: Tab;
-
-  // Setters
-  setUserType: (type: UserType | null) => void;
-  setCurrentBar: (bar: Bar | null) => void;
-  setCustomerName: (name: string) => void;
-  setLanguage: (lang: Language) => void;
-  setLoading: (loading: boolean) => void;
-  setError: (error: string | null) => void;
-  setBarForm: React.Dispatch<React.SetStateAction<BarForm>>;
-  setLoginForm: React.Dispatch<React.SetStateAction<LoginForm>>;
-  setDrinks: React.Dispatch<React.SetStateAction<Drink[]>>;
-  setOrders: React.Dispatch<React.SetStateAction<Order[]>>;
-  setAnalytics: React.Dispatch<React.SetStateAction<Analytics | null>>;
-  setCategories: React.Dispatch<React.SetStateAction<Category[]>>;
-  setEditingDrink: (drink: Drink | "new" | null) => void;
-  setViewingRecipe: (drink: Drink | null) => void;
-  setShowPassword: (show: boolean) => void;
-  setCurrentTab: (tab: Tab) => void;
-
-  // API helper
-  apiCall: (endpoint: string, options?: RequestInit) => Promise<any>;
-}
-
-const AppContext = createContext<AppContextType | undefined>(undefined);
-
-export const useApp = () => {
-  const context = useContext(AppContext);
-  if (context === undefined) {
-    throw new Error("useApp must be used within an AppProvider");
-  }
-  return context;
-};
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({
   children,

--- a/frontend/src/context/LiveUpdatesContext.tsx
+++ b/frontend/src/context/LiveUpdatesContext.tsx
@@ -1,33 +1,15 @@
 import React, {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useRef,
   useState,
   ReactNode,
 } from "react";
-import { useApp } from "./AppContext";
+import { useApp } from "../hooks/useApp";
+import { LiveUpdatesContext } from "../hooks/useLiveUpdates";
 import type { LiveUpdate } from "../types";
 
-interface LiveUpdatesContextType {
-  isConnected: boolean;
-  connectionError: boolean;
-  reconnect: () => void;
-}
 
-const LiveUpdatesContext = createContext<LiveUpdatesContextType | undefined>(
-  undefined
-);
-
-// eslint-disable-next-line react-refresh/only-export-components
-export const useLiveUpdates = () => {
-  const context = useContext(LiveUpdatesContext);
-  if (context === undefined) {
-    throw new Error("useLiveUpdates must be used within a LiveUpdatesProvider");
-  }
-  return context;
-};
 
 // How long to stay quiet before telling anyone. The browser reconnects on its
 // own, so short drops are not worth mentioning.

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -1,0 +1,94 @@
+import React, { createContext, useContext } from "react";
+
+import type {
+  Analytics,
+  Bar,
+  Category,
+  Drink,
+  Language,
+  Order,
+  UserType,
+} from "../types";
+
+/** The bartender's tabs, in the order they appear. */
+export type Tab =
+  | "orders"
+  | "menu"
+  | "analytics"
+  | "categories"
+  | "settings";
+
+/** The two sign-in forms hold the same handful of fields throughout. */
+type BarForm = {
+  name: string;
+  bartenderPassword: string;
+  guestPassword: string;
+  language: Language;
+};
+
+type LoginForm = { password: string; name: string };
+
+export interface AppContextType {
+  // App state
+  userType: UserType | null;
+  currentBar: Bar | null;
+  customerName: string;
+  language: Language;
+
+  // Loading and error states
+  loading: boolean;
+  error: string | null;
+
+  // Form states
+  barForm: BarForm;
+  loginForm: LoginForm;
+
+  // Data states
+  drinks: Drink[];
+  orders: Order[];
+  analytics: Analytics | null;
+  categories: Category[];
+
+  // UI states
+  editingDrink: Drink | "new" | null;
+  viewingRecipe: Drink | null;
+  showPassword: boolean;
+  currentTab: Tab;
+
+  // Setters
+  setUserType: (type: UserType | null) => void;
+  setCurrentBar: (bar: Bar | null) => void;
+  setCustomerName: (name: string) => void;
+  setLanguage: (lang: Language) => void;
+  setLoading: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  setBarForm: React.Dispatch<React.SetStateAction<BarForm>>;
+  setLoginForm: React.Dispatch<React.SetStateAction<LoginForm>>;
+  setDrinks: React.Dispatch<React.SetStateAction<Drink[]>>;
+  setOrders: React.Dispatch<React.SetStateAction<Order[]>>;
+  setAnalytics: React.Dispatch<React.SetStateAction<Analytics | null>>;
+  setCategories: React.Dispatch<React.SetStateAction<Category[]>>;
+  setEditingDrink: (drink: Drink | "new" | null) => void;
+  setViewingRecipe: (drink: Drink | null) => void;
+  setShowPassword: (show: boolean) => void;
+  setCurrentTab: (tab: Tab) => void;
+
+  // API helper
+  apiCall: <T = unknown>(
+    endpoint: string,
+    options?: RequestInit
+  ) => Promise<T>;
+}
+
+export const AppContext = createContext<AppContextType | undefined>(undefined);
+
+/** Everything the pages share: who is signed in, what is on, and the API. */
+export function useApp(): AppContextType {
+  const context = useContext(AppContext);
+
+  if (context === undefined) {
+    throw new Error("useApp must be used within an AppProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/hooks/useGuestMenu.ts
+++ b/frontend/src/hooks/useGuestMenu.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 import type { Drink } from "../types";
 import { BASE_SPIRITS } from "../utils/spirits";
 

--- a/frontend/src/hooks/useLiveUpdates.ts
+++ b/frontend/src/hooks/useLiveUpdates.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+export interface LiveUpdatesContextType {
+  isConnected: boolean;
+  connectionError: boolean;
+  reconnect: () => void;
+}
+
+export const LiveUpdatesContext = createContext<
+  LiveUpdatesContextType | undefined
+>(undefined);
+
+/** How the live connection is doing, and a way to try it again. */
+export function useLiveUpdates(): LiveUpdatesContextType {
+  const context = useContext(LiveUpdatesContext);
+
+  if (context === undefined) {
+    throw new Error("useLiveUpdates must be used within a LiveUpdatesProvider");
+  }
+
+  return context;
+}

--- a/frontend/src/hooks/useSessionManager.ts
+++ b/frontend/src/hooks/useSessionManager.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
 
 const SESSION_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 export const ACTIVITY_KEY = "homeBarSystem_lastActivity";
@@ -12,32 +12,31 @@ export const useSessionManager = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const updateActivity = () => {
+  const updateActivity = useCallback(() => {
     localStorage.setItem(ACTIVITY_KEY, Date.now().toString());
-  };
+  }, []);
 
-  const checkSessionTimeout = () => {
+  const hasTimedOut = useCallback(() => {
     const lastActivity = localStorage.getItem(ACTIVITY_KEY);
     if (!lastActivity) return false;
 
-    const timeSinceActivity = Date.now() - parseInt(lastActivity);
-    return timeSinceActivity > SESSION_TIMEOUT;
-  };
+    return Date.now() - parseInt(lastActivity) > SESSION_TIMEOUT;
+  }, []);
 
-  const clearSession = () => {
+  const clearSession = useCallback(() => {
     navigate("/");
     setUserType(null);
     setCurrentBar(null);
     setCustomerName("");
-    setLoginForm({ password: "", name: "" }); // Clear login form fields
+    setLoginForm({ password: "", name: "" });
     localStorage.removeItem(ACTIVITY_KEY);
-  };
+  }, [navigate, setUserType, setCurrentBar, setCustomerName, setLoginForm]);
 
   useEffect(() => {
     const isOnLandingPage = location.pathname === "/";
 
     // Check for expired session on mount
-    if (!isOnLandingPage && checkSessionTimeout()) {
+    if (!isOnLandingPage && hasTimedOut()) {
       console.log("Session expired, clearing...");
       clearSession();
       return;
@@ -74,7 +73,7 @@ export const useSessionManager = () => {
         document.removeEventListener(event, handleActivity, true);
       });
     };
-  }, [location.pathname]);
+  }, [location.pathname, hasTimedOut, clearSession, updateActivity]);
 
   return { clearSession, updateActivity };
 };

--- a/frontend/src/pages/PastOrdersPage.tsx
+++ b/frontend/src/pages/PastOrdersPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { useApp } from "../context/AppContext";
+import { useApp } from "../hooks/useApp";
+import type { Drink, Order } from "../types";
 import { useTranslation } from "../utils/translations";
 import { ArrowLeft } from "lucide-react";
 import PastOrders from "../components/PastOrders";
@@ -33,7 +34,7 @@ const PastOrdersPage: React.FC = () => {
     navigate("/customer");
   };
 
-  const handlePlaceOrder = async (drink: any) => {
+  const handlePlaceOrder = async (drink: Drink) => {
     if (customerOrder) {
       alert("You can only have one active order at a time");
       return;
@@ -51,7 +52,7 @@ const PastOrdersPage: React.FC = () => {
       });
 
       // Refresh orders after placing order
-      const updatedOrders = await apiCall(`/orders/bar/${currentBar!.id}`);
+      const updatedOrders = await apiCall<Order[]>(`/orders/bar/${currentBar!.id}`);
       setOrders(updatedOrders);
 
       // Navigate back to customer interface to see the new order

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,11 +5,13 @@
 
 export type {
   Bar,
+  BarQrCode,
   Category,
   Flag,
   Language,
   LiveUpdate,
   OrderStatus,
+  SignedIn,
   UserType,
 } from "@shared/types";
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -7,10 +7,10 @@ const API_BASE = "/api";
  * A plain function rather than something built per render, so anything that
  * reloads when it changes never has to.
  */
-export async function apiCall(
+export async function apiCall<T = unknown>(
   endpoint: string,
   options: RequestInit = {}
-): Promise<any> {
+): Promise<T> {
   const response = await fetch(`${API_BASE}${endpoint}`, {
     headers: {
       "Content-Type": "application/json",

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -88,6 +88,24 @@ export interface Favourite {
   created_at: string;
 }
 
+/** The reply to signing in, or to checking a session is still good. */
+export interface SignedIn {
+  success: true;
+  userType: UserType;
+  bar: Bar;
+  /** Only when a guest signs in. */
+  customerName?: string;
+}
+
+/** A printable code that takes a guest straight to the bar. */
+export interface BarQrCode {
+  barId: number;
+  barName: string;
+  url: string;
+  /** The image itself, ready to drop into an <img>. */
+  qrCode: string;
+}
+
 /** How busy the bar has been, for the reports tab. */
 export interface OrderAnalytics {
   totalOrders: number;


### PR DESCRIPTION
Closes #37 — the tidy-up pass, kept until last as agreed.

**25 warnings → 0**, in both halves, at `--max-warnings 0`. `no-explicit-any` and `no-empty-object-type` are errors again.

## The `any` types

`apiCall` is generic now, so a caller states what it expects:

```ts
setDrinks(await apiCall<Drink[]>(`/drinks/bar/${barId}`));
```

Switching the default to `unknown` broke **19 call sites** — every one a payload that had never been typed. Two were API shapes with no name at all, so `SignedIn` and `BarQrCode` are in `shared/types.d.ts` and the routes return them with `satisfies`.

The rest: `["--color-fg-default" as any]` became a `React.CSSProperties` assertion on the object; `status as any` became an `OrderStatus` parameter; `PastOrders` took `orders: any[]` and `customerOrder: any`; `LoginForm` built its body as `any` so it could add a field conditionally, which is a spread now.

## The effect dependencies

Fixed rather than silenced, as the issue asked. This only became possible once `apiCall` was stable (#30) — before that, listing it would have re-run the effects on every render.

The fetchers in `BarSelector`, `BartenderDashboard`, `CategoriesTab` and `DrinkForm` are memoised on `barId` and listed properly, so a stale closure can't hold an old bar id. `useSessionManager`'s `clearSession` likewise — that one sits in the session-timeout effect, exactly where the issue warned a stale closure would produce "it stopped updating".

`ImageCropper` was the one needing thought: it watched `initialCrop.x`/`.y` while the rule wanted the object, but the caller rebuilds that object every render, so depending on it would reset the crop mid-drag. It destructures the two numbers instead.

## Fast refresh

`useApp` and `useLiveUpdates`, and the contexts they read, moved to `hooks/`. Those files export no components, so the providers hot-reload properly and the `eslint-disable` in `LiveUpdatesContext` is gone.

## Keeping it clean

Both `lint` scripts run with `--max-warnings 0` and CI calls them, so warnings can't quietly accumulate again. `CLAUDE.md` says `any` is an error in both halves, and that an unknown shape belongs in `shared/types.d.ts`.

## Checked

70 backend tests, both linters, both typecheckers, both builds — clean.

Ran the built image against a copy of the production database and drove it in a headless browser again, since this touched sign-in, the live connection and the session hook:

- guest page: 18 sections, 302 cards, Gin filter gives 31, surprise-me and Escape work, **every endpoint fetched exactly once**
- bartender: reports, drink form populated correctly, add-drink blank, QR modal renders its image and address
- no console errors anywhere