### PR TITLE
Add tests for the pages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@ uploads
 **/.vscode
 **/.idea
 
+# Tests are not needed to build the image.
+frontend/tests
+
 compose.yaml
 compose.dev.yaml
 README.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,6 +51,14 @@ jobs:
         working-directory: frontend
         run: npm run lint
 
+      - name: Typecheck frontend
+        working-directory: frontend
+        run: npm run typecheck
+
+      - name: Test frontend
+        working-directory: frontend
+        run: npm test
+
       - name: Build frontend
         working-directory: frontend
         run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Test the `staging` image against a copy of the real data before releasing.
 
 ```sh
 cd backend  && npm test && npm run lint && npm run typecheck
-cd frontend && npm run lint && npm run build
+cd frontend && npm test && npm run lint && npm run typecheck && npm run build
 ```
 
 Both linters fail on a warning, so anything new has to be dealt with rather
@@ -114,17 +114,40 @@ text.
 
 ## Tests
 
+Both halves use Vitest, both in `tests/`, both run by `npm test`.
+
+### The server
+
 `createApp()` takes the database and folders it should use, so a test hands in
-its own and nothing touches real data. `tests/helpers.js` has the pieces:
+its own and nothing touches real data. `tests/helpers.ts` has the pieces:
 `makeTestApp()` for a wired-up app, `makeEmptyDatabase()` for testing the
 migration steps, `seedBar()` for something to order.
 
 Live updates are checked by putting a stand-in on `app.locals.wss` and looking
 at what got sent, rather than opening a real connection.
 
+### The pages
+
+These run against a stand-in browser, so no server and no real browser are
+needed. `tests/helpers.tsx` has the pieces: `fakeApi()` answers requests and
+records them, `signIn()` sets up a session the way a real one is remembered,
+`FakeEventSource` stands in for live updates and is driven by hand, and
+`aBar`/`aDrink`/`anOrder` make something to work with.
+
+Ask for things the way a guest would — the button that says "Order", the text
+they would read — rather than by class name, so a test breaks when the app
+does and not when the styling changes.
+
+### Both
+
 Cover the behaviour, not the wiring. The tests worth having are the ones for
 things that have actually gone wrong before: migrations against half-updated
-databases, handler order, and anything touching files on disk.
+databases, handler order, anything touching files on disk, and anything that
+reloads or reconnects on its own.
+
+A test for a bug should fail against the old code. Worth actually checking by
+putting the old behaviour back for a moment — a regression test that passes
+either way is not testing anything.
 
 ## Don't commit
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -42,4 +42,10 @@ export default [
       "@typescript-eslint/no-empty-object-type": "error",
     },
   },
+  {
+    files: ["tests/**/*.{ts,tsx}", "vitest.config.ts"],
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.node },
+    },
+  },
 ];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,10 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.11",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.3",
         "@types/react": "19.1.8",
         "@types/react-dom": "19.1.6",
         "@typescript-eslint/eslint-plugin": "8.36.0",
@@ -28,11 +32,20 @@
         "eslint": "9.31.0",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
+        "jsdom": "^30.0.1",
         "postcss": "8.5.6",
         "tailwindcss": "^4.1.11",
         "typescript": "5.8.3",
-        "vite": "7.0.4"
+        "vite": "7.0.4",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -59,6 +72,59 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -370,6 +436,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1000,6 +1219,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1101,9 +1338,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1443,6 +1680,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
@@ -1719,6 +1963,105 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1764,6 +2107,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1772,6 +2126,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2199,6 +2560,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2270,6 +2744,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2333,6 +2827,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolbase": {
@@ -2445,6 +2949,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2607,11 +3121,61 @@
       ],
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2638,6 +3202,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -2710,6 +3281,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.182",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
@@ -2748,6 +3326,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.6",
@@ -3052,6 +3637,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3060,6 +3655,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3561,6 +4166,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -3616,6 +4234,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -3722,6 +4350,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3757,6 +4392,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -4121,14 +4833,24 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -4422,6 +5144,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5010,6 +5739,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -5130,6 +5869,20 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -5266,6 +6019,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5339,6 +6099,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/property-information": {
@@ -5434,6 +6222,13 @@
         "react-dom": ">=16.4.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-markdown": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.3.tgz",
@@ -5506,6 +6301,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/refractor": {
@@ -5829,6 +6638,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -5920,6 +6739,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -5974,6 +6806,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5993,6 +6832,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6029,6 +6882,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6078,6 +6944,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
@@ -6123,15 +6996,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6141,11 +7031,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -6156,9 +7049,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6167,6 +7060,36 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -6179,6 +7102,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -6245,6 +7194,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -6537,6 +7496,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6545,6 +7620,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6569,6 +7679,23 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6592,6 +7719,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "4.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint src --max-warnings 0"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src tests --max-warnings 0",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@types/qrcode": "^1.5.5",
@@ -21,6 +24,10 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.3",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",
     "@typescript-eslint/eslint-plugin": "8.36.0",
@@ -30,9 +37,11 @@
     "eslint": "9.31.0",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20",
+    "jsdom": "^30.0.1",
     "postcss": "8.5.6",
     "tailwindcss": "^4.1.11",
     "typescript": "5.8.3",
-    "vite": "7.0.4"
+    "vite": "7.0.4",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/tests/drinks.test.tsx
+++ b/frontend/tests/drinks.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import DrinkCard from "../src/components/DrinkCard";
+import DrinkGrid from "../src/components/customer/DrinkGrid";
+import { statusCard, statusCardWithText, statusIcon } from "../src/utils/orderStatus";
+import { translations, type TranslationKeys } from "../src/utils/translations";
+import type { OrderStatus } from "../src/types";
+import { aDrink } from "./helpers";
+
+const t = (key: TranslationKeys) => translations.en[key] as string;
+
+const cardActions = {
+  onViewRecipe: vi.fn(),
+  onOrder: vi.fn(),
+  onToggleFavourite: vi.fn(),
+  disabled: false,
+  loading: false,
+  t,
+};
+
+describe("a drink on the menu", () => {
+  // in_stock arrives as 0 or 1, and used to be typed as a boolean.
+  it("offers a drink that is in stock", async () => {
+    const onOrder = vi.fn();
+    render(
+      <DrinkCard {...cardActions} onOrder={onOrder} drink={aDrink({ in_stock: 1 })} />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /order/i }));
+
+    expect(onOrder).toHaveBeenCalledOnce();
+  });
+
+  it("marks a favourite as one, and an ordinary drink as not", () => {
+    const { rerender } = render(
+      <DrinkCard {...cardActions} drink={aDrink({ is_favourite: 1 })} />
+    );
+    expect(
+      screen.getByTitle("Remove from favourites")
+    ).toBeInTheDocument();
+
+    rerender(<DrinkCard {...cardActions} drink={aDrink({ is_favourite: 0 })} />);
+    expect(screen.getByTitle("Add to favourites")).toBeInTheDocument();
+  });
+
+  it("shows a drink with no picture without breaking", () => {
+    render(<DrinkCard {...cardActions} drink={aDrink({ image_url: null })} />);
+
+    expect(screen.getByText("Negroni")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});
+
+describe("a section of the menu", () => {
+  const drinks = [
+    aDrink({ id: 1, title: "Negroni" }),
+    aDrink({ id: 2, title: "Aviation" }),
+  ];
+
+  it("lists every drink under its heading", () => {
+    render(
+      <DrinkGrid
+        {...cardActions}
+        drinks={drinks}
+        heading="Gin"
+        headingClass="text-blue-800"
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Gin" })).toBeInTheDocument();
+    expect(screen.getByText("Negroni")).toBeInTheDocument();
+    expect(screen.getByText("Aviation")).toBeInTheDocument();
+  });
+
+  it("can be linked to from the menu on the left", () => {
+    const { container } = render(
+      <DrinkGrid
+        {...cardActions}
+        drinks={drinks}
+        id="favourites"
+        heading="Favourites"
+        headingClass="text-yellow-700"
+      />
+    );
+
+    expect(container.querySelector("section")).toHaveAttribute(
+      "id",
+      "favourites"
+    );
+  });
+});
+
+describe("how an order looks at each step", () => {
+  const every: OrderStatus[] = [
+    "new",
+    "accepted",
+    "rejected",
+    "ready",
+    "processed",
+  ];
+
+  it("has an icon and colours for every step, with nothing left over", () => {
+    for (const status of every) {
+      expect(statusIcon(status)).toBeTruthy();
+      expect(statusCard(status)).toMatch(/^bg-\S+ border-\S+$/);
+      expect(statusCardWithText(status)).toContain(statusCard(status));
+      expect(statusCardWithText(status)).toMatch(/text-\S+$/);
+    }
+  });
+
+  it("gives each step its own colour", () => {
+    const colours = new Set(every.map(statusCard));
+
+    expect(colours.size).toBe(every.length);
+  });
+});

--- a/frontend/tests/guestMenu.test.tsx
+++ b/frontend/tests/guestMenu.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+
+import { useGuestMenu } from "../src/hooks/useGuestMenu";
+import { aDrink, fakeApi, signIn, withApp, type FakeApi } from "./helpers";
+
+const MENU = [
+  aDrink({ id: 1, title: "Negroni", base_spirit: "Gin", category_name: "Classics" }),
+  aDrink({ id: 2, title: "Aviation", base_spirit: "Gin", category_name: "Classics" }),
+  aDrink({ id: 3, title: "Daiquiri", base_spirit: "Rum", category_name: "Sours" }),
+  aDrink({ id: 4, title: "Old Fashioned", base_spirit: "Whisky/Whiskey" }),
+  // Off the menu tonight, so it should not appear anywhere.
+  aDrink({ id: 5, title: "Mojito", base_spirit: "Rum", in_stock: 0 }),
+];
+
+let api: FakeApi;
+
+beforeEach(() => {
+  signIn();
+  api = fakeApi((path) => {
+    if (path.includes("/favourites/")) return [aDrink({ id: 2, title: "Aviation" })];
+    if (path.includes("/drinks/bar/")) return MENU;
+    if (path.includes("/orders/bar/")) return [];
+    return undefined;
+  });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+const openMenu = async () => {
+  const view = renderHook(() => useGuestMenu(), { wrapper: withApp });
+  await waitFor(() => expect(view.result.current.inStock.length).toBe(4));
+  return view;
+};
+
+describe("the guest's menu", () => {
+  it("leaves out anything that is not in stock", async () => {
+    const { result } = await openMenu();
+
+    expect(result.current.inStock.map((d) => d.title)).not.toContain("Mojito");
+    expect(result.current.bySpirit["Rum"]).toHaveLength(1);
+  });
+
+  it("groups by spirit in the bar's order, not alphabetically", async () => {
+    const { result } = await openMenu();
+
+    expect(result.current.spirits).toEqual(["Gin", "Rum", "Whisky/Whiskey"]);
+  });
+
+  it("sorts the drinks inside each group by name", async () => {
+    const { result } = await openMenu();
+
+    expect(result.current.bySpirit["Gin"].map((d) => d.title)).toEqual([
+      "Aviation",
+      "Negroni",
+    ]);
+  });
+
+  it("files a drink with no category under Uncategorized", async () => {
+    const { result } = await openMenu();
+
+    expect(result.current.categories).toEqual([
+      "Classics",
+      "Sours",
+      "Uncategorized",
+    ]);
+    expect(result.current.byCategory["Uncategorized"]).toHaveLength(1);
+  });
+
+  it("shows the chosen group only, and every group when none is chosen", async () => {
+    const { result } = await openMenu();
+
+    expect(result.current.filtered).toEqual([]);
+
+    act(() => result.current.setFilter({ type: "spirit", value: "Gin" }));
+    expect(result.current.filtered.map((d) => d.title)).toEqual([
+      "Aviation",
+      "Negroni",
+    ]);
+
+    act(() => result.current.setFilter({ type: "category", value: "Sours" }));
+    expect(result.current.filtered.map((d) => d.title)).toEqual(["Daiquiri"]);
+  });
+
+  it("puts the favourites in alphabetical order", async () => {
+    api = fakeApi((path) => {
+      if (path.includes("/favourites/"))
+        return [aDrink({ id: 3, title: "Zombie" }), aDrink({ id: 2, title: "Aviation" })];
+      if (path.includes("/drinks/bar/")) return MENU;
+      if (path.includes("/orders/bar/")) return [];
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useGuestMenu(), { wrapper: withApp });
+
+    await waitFor(() =>
+      expect(result.current.favourites.map((d) => d.title)).toEqual([
+        "Aviation",
+        "Zombie",
+      ])
+    );
+  });
+
+  // apiCall used to be rebuilt on every render, so the effect that loads the
+  // menu listed a dependency that never stopped changing.
+  it("loads each thing once and then stops", async () => {
+    const { rerender } = await openMenu();
+
+    rerender();
+    rerender();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(api.countOf("/drinks/bar/1/guest/")).toBe(1);
+    expect(api.countOf("/favourites/")).toBe(1);
+    expect(api.countOf("/orders/bar/1")).toBe(1);
+  });
+
+  it("asks for the guest's own list, so favourites come back marked", async () => {
+    await openMenu();
+
+    expect(api.calls.map((c) => c.path)).toContain(
+      "/api/drinks/bar/1/guest/Ada"
+    );
+  });
+
+  it("escapes a name that would otherwise break the address", async () => {
+    localStorage.clear();
+    signIn({ name: "Ada & Bob" });
+
+    renderHook(() => useGuestMenu(), { wrapper: withApp });
+
+    await waitFor(() =>
+      expect(api.calls.map((c) => c.path)).toContain(
+        "/api/drinks/bar/1/guest/Ada%20%26%20Bob"
+      )
+    );
+  });
+});

--- a/frontend/tests/helpers.tsx
+++ b/frontend/tests/helpers.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+import { AppProvider } from "../src/context/AppContext";
+import type { Bar, Drink, Order, OrderStatus } from "../src/types";
+
+/** A bar with nothing unusual about it. */
+export const aBar = (extra: Partial<Bar> = {}): Bar => ({
+  id: 1,
+  name: "The Spotted Cow",
+  language: "en",
+  skip_approval: 0,
+  created_at: "2025-07-13 14:23:32",
+  ...extra,
+});
+
+export const aDrink = (extra: Partial<Drink> = {}): Drink => ({
+  id: 1,
+  bar_id: 1,
+  title: "Negroni",
+  image_url: null,
+  recipe: "gin, campari, vermouth",
+  in_stock: 1,
+  base_spirit: "Gin",
+  guest_description: null,
+  show_recipe_to_guests: 0,
+  category_id: null,
+  category_name: null,
+  image_crop_x: 0,
+  image_crop_y: 0,
+  image_crop_zoom: 1,
+  created_at: "2025-07-13 14:23:32",
+  ...extra,
+});
+
+export const anOrder = (extra: Partial<Order> = {}): Order => ({
+  id: 1,
+  bar_id: 1,
+  customer_name: "Ada",
+  drink_id: 1,
+  drink_title: "Negroni",
+  status: "new" as OrderStatus,
+  created_at: "2025-07-13 14:23:32",
+  updated_at: "2025-07-13 14:23:32",
+  ...extra,
+});
+
+/** Signs someone in, the way a real session is remembered. */
+export function signIn({
+  bar = aBar(),
+  as = "guest",
+  name = "Ada",
+}: { bar?: Bar; as?: "guest" | "bartender"; name?: string } = {}): void {
+  localStorage.setItem("homeBarSystem_userType", JSON.stringify(as));
+  localStorage.setItem("homeBarSystem_currentBar", JSON.stringify(bar));
+  if (as === "guest") {
+    localStorage.setItem("homeBarSystem_customerName", JSON.stringify(name));
+  }
+}
+
+export interface FakeApi {
+  /** Every request made, oldest first. */
+  calls: Array<{ path: string; method: string; body: unknown }>;
+  /** How many requests went to a path containing this. */
+  countOf: (fragment: string) => number;
+}
+
+/**
+ * Stands in for the server. `reply` gets the path and returns the body;
+ * returning undefined answers with a 404, so a route nobody set up is
+ * obvious rather than silently empty.
+ */
+export function fakeApi(
+  reply: (path: string, options: RequestInit) => unknown
+): FakeApi {
+  const calls: FakeApi["calls"] = [];
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, options: RequestInit = {}) => {
+      const path = String(url);
+      calls.push({
+        path,
+        method: options.method ?? "GET",
+        body: options.body ? JSON.parse(String(options.body)) : undefined,
+      });
+
+      const body = reply(path, options);
+
+      return {
+        ok: body !== undefined,
+        status: body === undefined ? 404 : 200,
+        json: async () => body ?? { error: "Not found" },
+      } as Response;
+    })
+  );
+
+  return {
+    calls,
+    countOf: (fragment) => calls.filter((c) => c.path.includes(fragment)).length,
+  };
+}
+
+/** Wraps whatever is being tested in the shared state the pages expect. */
+export const withApp = ({ children }: { children: ReactNode }) => (
+  <AppProvider>{children}</AppProvider>
+);
+
+type Listener = ((event: MessageEvent) => void) | null;
+
+/**
+ * A stand-in for the browser's own EventSource, which jsdom does not have.
+ * Tests drive it by hand: open it, send an update, make it fail.
+ */
+export class FakeEventSource {
+  static opened: FakeEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: Listener = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(readonly url: string) {
+    FakeEventSource.opened.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** The ones still connected, which is what a leak would show up in. */
+  static get live(): FakeEventSource[] {
+    return FakeEventSource.opened.filter((s) => !s.closed);
+  }
+
+  static reset(): void {
+    FakeEventSource.opened = [];
+  }
+
+  connect(): void {
+    this.onopen?.();
+  }
+
+  send(update: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(update) } as MessageEvent);
+  }
+
+  drop(): void {
+    this.onerror?.();
+  }
+}

--- a/frontend/tests/liveUpdates.test.tsx
+++ b/frontend/tests/liveUpdates.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+
+import { LiveUpdatesProvider } from "../src/context/LiveUpdatesContext";
+import { useApp } from "../src/hooks/useApp";
+import { useLiveUpdates } from "../src/hooks/useLiveUpdates";
+import { AppProvider } from "../src/context/AppContext";
+import {
+  anOrder,
+  fakeApi,
+  FakeEventSource,
+  signIn,
+  type FakeApi,
+} from "./helpers";
+
+let api: FakeApi;
+let served: ReturnType<typeof anOrder>[];
+
+/** Shows just enough to see what the live connection did. */
+const Probe: React.FC = () => {
+  const { orders } = useApp();
+  const { isConnected, connectionError, reconnect } = useLiveUpdates();
+
+  return (
+    <div>
+      <span data-testid="orders">{orders.map((o) => o.id).join(",")}</span>
+      <span data-testid="connected">{String(isConnected)}</span>
+      {connectionError && <span data-testid="notice">lost</span>}
+      <button onClick={reconnect}>try again</button>
+    </div>
+  );
+};
+
+const show = () =>
+  render(
+    <AppProvider>
+      <LiveUpdatesProvider>
+        <Probe />
+      </LiveUpdatesProvider>
+    </AppProvider>
+  );
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+  signIn();
+  served = [anOrder({ id: 7 }), anOrder({ id: 8 })];
+  api = fakeApi((path) => (path.includes("/orders/bar/") ? served : undefined));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("live updates", () => {
+  it("watches the bar the guest is in", async () => {
+    show();
+
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+    expect(FakeEventSource.live[0].url).toBe("/api/events?barId=1");
+  });
+
+  it("fetches the orders again when one arrives or changes", async () => {
+    show();
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+
+    // Nothing is fetched until something happens; the page loads the first
+    // list itself.
+    expect(api.countOf("/orders/bar/1")).toBe(0);
+
+    act(() =>
+      FakeEventSource.live[0].send({
+        type: "new_order",
+        order: anOrder({ id: 8 }),
+      })
+    );
+
+    await screen.findByText("7,8");
+    expect(api.countOf("/orders/bar/1")).toBe(1);
+  });
+
+  it("takes an order off the list when it is cancelled", async () => {
+    show();
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+
+    act(() =>
+      FakeEventSource.live[0].send({
+        type: "new_order",
+        order: anOrder({ id: 8 }),
+      })
+    );
+    await screen.findByText("7,8");
+
+    act(() =>
+      FakeEventSource.live[0].send({ type: "order_deleted", orderId: 7 })
+    );
+
+    expect(screen.getByTestId("orders")).toHaveTextContent("8");
+  });
+
+  // The connection used to be torn down and reopened every time an order came
+  // in, because apiCall was rebuilt on every render.
+  it("keeps the same connection while orders come and go", async () => {
+    show();
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+    const first = FakeEventSource.live[0];
+
+    for (const id of [9, 10, 11]) {
+      served = [...served, anOrder({ id })];
+      act(() => first.send({ type: "new_order", order: anOrder({ id }) }));
+      await screen.findByText(served.map((o) => o.id).join(","));
+    }
+
+    expect(FakeEventSource.opened).toHaveLength(1);
+    expect(first.closed).toBe(false);
+  });
+
+  it("stays quiet about a blip, and speaks up if it lasts", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    show();
+
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+    act(() => FakeEventSource.live[0].connect());
+    expect(screen.getByTestId("connected")).toHaveTextContent("true");
+
+    act(() => FakeEventSource.live[0].drop());
+    act(() => void vi.advanceTimersByTime(10_000));
+    expect(screen.queryByTestId("notice")).toBeNull();
+
+    act(() => void vi.advanceTimersByTime(6_000));
+    expect(screen.getByTestId("notice")).toBeInTheDocument();
+  });
+
+  it("says nothing if it comes back before anyone would notice", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    show();
+
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+    act(() => FakeEventSource.live[0].drop());
+    act(() => void vi.advanceTimersByTime(5_000));
+    act(() => FakeEventSource.live[0].connect());
+    act(() => void vi.advanceTimersByTime(30_000));
+
+    expect(screen.queryByTestId("notice")).toBeNull();
+  });
+
+  it("hangs up when the page goes away", async () => {
+    const { unmount } = show();
+    await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
+
+    unmount();
+
+    expect(FakeEventSource.live).toHaveLength(0);
+  });
+
+  it("does not connect at all until someone is signed in", async () => {
+    localStorage.clear();
+    show();
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(FakeEventSource.opened).toHaveLength(0);
+  });
+});

--- a/frontend/tests/ordering.test.tsx
+++ b/frontend/tests/ordering.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+
+import CustomerInterface from "../src/components/CustomerInterface";
+import RecipeView from "../src/components/RecipeView";
+import { AppProvider } from "../src/context/AppContext";
+import { LiveUpdatesProvider } from "../src/context/LiveUpdatesContext";
+import {
+  aDrink,
+  anOrder,
+  fakeApi,
+  FakeEventSource,
+  signIn,
+  withApp,
+  type FakeApi,
+} from "./helpers";
+
+let api: FakeApi;
+let orders: ReturnType<typeof anOrder>[];
+
+let menu: ReturnType<typeof aDrink>[];
+
+const serve = () => {
+  api = fakeApi((path, options) => {
+    if (path.includes("/favourites/")) return [];
+    if (path.includes("/drinks/bar/")) return menu;
+    if (path.includes("/orders/bar/")) return orders;
+    if (path === "/api/orders" && options.method === "POST") {
+      orders = [anOrder({ id: 99, drink_title: "Negroni" })];
+      return orders[0];
+    }
+    if (path.startsWith("/api/orders/") && options.method === "DELETE") {
+      orders = [];
+      return { success: true };
+    }
+    return undefined;
+  });
+};
+
+const showMenu = async () => {
+  render(
+    <MemoryRouter>
+      <AppProvider>
+        <LiveUpdatesProvider>
+          <CustomerInterface />
+        </LiveUpdatesProvider>
+      </AppProvider>
+    </MemoryRouter>
+  );
+  await screen.findAllByRole("button", { name: "Order" });
+};
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+  signIn();
+  orders = [];
+  menu = [
+    aDrink({ id: 1, title: "Negroni", base_spirit: "Gin" }),
+    aDrink({ id: 2, title: "Daiquiri", base_spirit: "Rum" }),
+  ];
+  serve();
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ordering a drink", () => {
+  it("sends the order and says so", async () => {
+    menu = [aDrink({ id: 1, title: "Negroni", base_spirit: "Gin" })];
+    await showMenu();
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Order" })[0]
+    );
+
+    await waitFor(() =>
+      expect(api.calls.some((c) => c.method === "POST")).toBe(true)
+    );
+
+    const posted = api.calls.find((c) => c.method === "POST");
+    expect(posted?.body).toMatchObject({
+      barId: 1,
+      customerName: "Ada",
+      drinkId: 1,
+      drinkTitle: "Negroni",
+    });
+    expect(await screen.findByText(/order placed/i)).toBeInTheDocument();
+  });
+
+  // One drink at a time, or the bartender ends up with a queue per guest.
+  it("will not take a second order while one is still on the go", async () => {
+    orders = [anOrder({ id: 5, status: "accepted" })];
+
+    await showMenu();
+    await screen.findByText("Your Order");
+
+    for (const button of screen.getAllByRole("button", { name: "Order" })) {
+      expect(button).toBeDisabled();
+    }
+
+    await userEvent.click(screen.getAllByRole("button", { name: "Order" })[0]);
+    expect(api.calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("shows how the order is getting on", async () => {
+    orders = [anOrder({ id: 5, status: "ready", drink_title: "Negroni" })];
+
+    await showMenu();
+
+    const card = (await screen.findByText("Your Order")).closest("div.rounded-lg");
+    expect(card).toHaveTextContent("Negroni");
+    expect(card).toHaveTextContent("Ready");
+  });
+
+  it("asks before cancelling, and does nothing if you say no", async () => {
+    orders = [anOrder({ id: 5, status: "new" })];
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(false));
+
+    await showMenu();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(api.calls.some((c) => c.method === "DELETE")).toBe(false);
+  });
+
+  it("cancels when you say yes", async () => {
+    orders = [anOrder({ id: 5, status: "new" })];
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
+
+    await showMenu();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(api.calls.some((c) => c.method === "DELETE")).toBe(true)
+    );
+    const sent = api.calls.find((c) => c.method === "DELETE");
+    expect(sent?.body).toMatchObject({ barId: 1, customerName: "Ada" });
+  });
+
+  it("says so plainly when there is nothing on", async () => {
+    menu = [];
+
+    render(
+      <MemoryRouter>
+        <AppProvider>
+          <LiveUpdatesProvider>
+            <CustomerInterface />
+          </LiveUpdatesProvider>
+        </AppProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByText("No drinks available right now")
+    ).toBeInTheDocument();
+  });
+});
+
+describe("looking at a recipe", () => {
+  // A drink with no recipe used to throw, because the recipe was typed as
+  // always being there.
+  it("opens a drink that has no recipe written down", () => {
+    render(<RecipeView drink={aDrink({ recipe: null })} onClose={vi.fn()} />, {
+      wrapper: withApp,
+    });
+
+    expect(screen.getByText("Negroni")).toBeInTheDocument();
+  });
+
+  it("closes when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    render(<RecipeView drink={aDrink()} onClose={onClose} />, {
+      wrapper: withApp,
+    });
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, beforeEach } from "vitest";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/tests/storedState.test.ts
+++ b/frontend/tests/storedState.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  clearStoredState,
+  useStoredState,
+  STORAGE_PREFIX,
+} from "../src/hooks/useStoredState";
+
+describe("settings that survive a refresh", () => {
+  it("remembers a value and reads it back on the next visit", () => {
+    const first = renderHook(() => useStoredState("language", "en"));
+    act(() => first.result.current[1]("da"));
+
+    const later = renderHook(() => useStoredState("language", "en"));
+
+    expect(later.result.current[0]).toBe("da");
+  });
+
+  it("removes rather than saves a blank, so nothing is left behind", () => {
+    const { result } = renderHook(() =>
+      useStoredState<string | null>("currentBar", null)
+    );
+
+    act(() => result.current[1]("something"));
+    expect(localStorage.getItem(`${STORAGE_PREFIX}currentBar`)).not.toBeNull();
+
+    act(() => result.current[1](null));
+    expect(localStorage.getItem(`${STORAGE_PREFIX}currentBar`)).toBeNull();
+  });
+
+  // A half-written value used to throw during render, which showed the guest
+  // a blank page with no way back.
+  it("falls back to the default when the saved value is unreadable", () => {
+    localStorage.setItem(`${STORAGE_PREFIX}currentBar`, "{not json");
+
+    const { result } = renderHook(() => useStoredState("currentBar", null));
+
+    expect(result.current[0]).toBeNull();
+  });
+
+  it("keeps the setter stable, so effects listing it do not re-run", () => {
+    const { result, rerender } = renderHook(() =>
+      useStoredState("language", "en")
+    );
+    const first = result.current[1];
+
+    rerender();
+
+    expect(result.current[1]).toBe(first);
+  });
+});
+
+describe("signing out", () => {
+  // Logout used to call localStorage.clear(), which wiped anything else the
+  // same site had saved.
+  it("forgets this app's settings and leaves everything else alone", () => {
+    localStorage.setItem(`${STORAGE_PREFIX}userType`, '"guest"');
+    localStorage.setItem(`${STORAGE_PREFIX}customerName`, '"Ada"');
+    localStorage.setItem("somethingElse", "keep me");
+
+    clearStoredState();
+
+    expect(localStorage.getItem(`${STORAGE_PREFIX}userType`)).toBeNull();
+    expect(localStorage.getItem(`${STORAGE_PREFIX}customerName`)).toBeNull();
+    expect(localStorage.getItem("somethingElse")).toBe("keep me");
+  });
+});

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "tests", "vitest.config.ts"]
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    // The API shapes, the same ones the server builds against.
+    alias: { "@shared": new URL("../shared", import.meta.url).pathname },
+  },
+  test: {
+    // A stand-in browser, so components can be rendered and clicked.
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["tests/setup.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
The frontend had no tests. These run against a stand-in browser (jsdom), so they need **no server and no real browser** — `npm test`, about a second and a half. Same Vitest setup as the server, same `tests/` layout.

**37 tests**, weighted towards things that have actually gone wrong rather than towards coverage.

## The two that matter most

Both are regression tests for the `apiCall` identity bug from #44, and **both were checked by putting the old behaviour back**:

| Test | Against the old code |
| --- | --- |
| "loads each thing once and then stops" | fails — the menu reloads in a loop |
| "keeps the same connection while orders come and go" | fails — the live connection is dropped and reopened on every order |

A regression test that passes either way isn't testing anything, so I verified each one fails before it passes. That is now written into `CLAUDE.md`.

## The rest

**The guest's menu** — only what is in stock; grouped by spirit in the bar's order rather than alphabetically; sorted by name inside each group; a drink with no category filed under Uncategorized; the guest's own list requested so favourites come back marked, with the name escaped.

**Ordering** — the order posts the right body and confirms; a second order is refused while one is on the go; cancelling asks first and does nothing if you say no; an empty menu says so plainly.

**Live updates** — an order cancelled elsewhere disappears; a new one triggers a refresh; the notice waits out a blip and only speaks up if it lasts; the stream closes on unmount and never opens before sign-in.

**Saved settings** — survive a refresh; blanks are removed rather than stored; an unreadable value falls back instead of blanking the page; signing out leaves other sites' storage alone.

**Drinks** — a drink with no picture or no recipe still opens; `in_stock` and `is_favourite` read correctly as `0`/`1`; every order status has its own icon and colour.

## One thing the tests corrected

I first wrote the one-order-at-a-time test to expect an `alert`. It failed — the Order buttons are simply **disabled** while an order is in progress, and the alert is only a second line of defence. The test asserts what actually happens now.

## Wiring

- `npm test`, `npm run test:watch`, `npm run typecheck` in the frontend
- `tsconfig.test.json` so the test files are typechecked too — `npm run build` still compiles only `src`
- lint covers `tests/` as well, still at `--max-warnings 0`
- CI runs typecheck and tests between lint and build
- `frontend/tests` added to `.dockerignore`; confirmed the image still builds, starts healthy against a copy of the production database, and serves the pages

Queries go through what a guest would look for — the button that says "Order", the text they would read — so a test breaks when the app does, not when the styling changes.

## Not included

Browser end-to-end tests. The headless-browser runs I did by hand for #44 and #45 caught things these can't (real rendering, the actual container), but they need a built image and a ~350 MB browser download, which is a lot to put in CI for a garden bar. Happy to add Playwright as a separate opt-in job if you want it.