### PR TITLE
Rename to Barkeep, rewrite the README, and fix the past orders page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Working on the home bar
+# Working on Barkeep
 
 A small self-hosted bar. Guests browse a menu and order drinks; the bartender
 works the queue. Orders update live.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ services:
     restart: unless-stopped
     init: true
     ports:
-      - "127.0.0.1:21000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
@@ -71,6 +71,10 @@ docker compose up -d
 The port is bound to `127.0.0.1`, so only the machine itself can reach the bar.
 That is deliberate: put a reverse proxy in front to open it up. See
 [Putting a proxy in front](#putting-a-proxy-in-front) below.
+
+Change the first number if something else on the machine already uses 3000, and
+point the proxy at whatever you chose. The second number is the port inside the
+container and is better left alone.
 
 Two folders need to survive an upgrade:
 
@@ -123,7 +127,7 @@ If the proxy runs on the same machine, point it at the published port:
 
 ```caddyfile
 bar.example.com {
-	reverse_proxy localhost:21000
+	reverse_proxy localhost:3000
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,67 @@
-# Home Bar System
+# Barkeep
 
-A small self-hosted bar for a party. Guests pick a drink from a menu on their
-phone, the host works through the orders, and everyone's screen keeps itself up
-to date.
+Drinks on tap for your guests. Barkeep puts your bar's menu on everyone's
+phone, takes their orders, and keeps you on top of what to make next.
 
-It is meant for a garden bar among friends, not a shop. There are no accounts
-and no payments. A guest types their name, picks a drink, and waits.
+You run it yourself, on a machine at home. It is built for a party among
+friends, not for a shop: there are no accounts and nothing to pay. A guest
+scans a code, types their name, picks a drink, and waits.
 
-## What it does
+## How an evening goes
 
-### For guests
+You set up a bar and add the drinks you are pouring, each with a photo and a
+recipe. You print or show the QR code.
 
-- Browse the menu on a phone, grouped by category or by base spirit
-- See what is available right now; anything out of stock is not offered
-- Mark drinks as favourites, which then appear at the top of the menu
-- Order one drink at a time, and watch it move from ordered to being made to
-  ready
-- Cancel an order, as long as it has not been handed over
-- "Surprise me" picks a drink at random, with a try-again button
-- Look back at what they have had, and order the same again
-- Read the recipe, if the host has chosen to share it for that drink
+Guests scan it, give a name, and get the menu. They pick something. It lands in
+your queue.
 
-### For the host
+You accept it, make it, and mark it ready. Their phone keeps up as you go, so
+nobody has to ask whether their drink is coming. When you run out of something,
+you mark it out of stock and it stops being offered.
+
+## What guests get
+
+- A menu on their phone, grouped by category or by base spirit
+- Only what is actually available; anything out of stock is not offered
+- Favourites, which move to the top of their menu
+- One drink at a time, tracked from ordered to being made to ready
+- The ability to cancel, up until you hand it over
+- A "surprise me" button that picks something at random, with a try again
+- A list of what they have had, and a way to order the same thing again
+- The recipe, on the drinks you choose to share it for
+
+## What you get
 
 - A queue of orders to accept, mark ready, and mark done, oldest first
-- Optionally accept every order automatically, for when the bar is busy
-- Add drinks with a photo, a recipe, a base spirit, and a short description
-- Crop and reposition a photo so it sits nicely on the card
-- Choose per drink whether guests can read the recipe or only the description
-- Mark a drink as out of stock without deleting it
-- Sort drinks into categories
-- A QR code, to show or print, that takes a guest straight to the bar's menu
-- Simple figures: total orders, orders today, most popular drinks, busiest
-  hours
+- The option to accept everything automatically when the bar gets busy
+- Drinks with a photo, a recipe, a base spirit, and a short description for
+  guests
+- A cropping tool, so a photo sits nicely on the card
+- A choice, per drink, of whether guests see the recipe or only the description
+- Out of stock as a toggle, so you do not have to delete anything
+- Categories, for grouping the menu how you like
+- A QR code to show or print
+- Simple figures: orders in total and today, the most popular drinks, and when
+  the rush was
 
-### Both
+## Both
 
 - English and Danish, though some of the host's own screens are still English
   only
-- Screens update on their own as orders come and go, with no refreshing
-- If the connection drops, the browser reconnects by itself. Guests are only
-  told something is wrong if it stays down.
+- Everything updates on its own as orders come and go, with nothing to refresh
+- If a phone loses signal it reconnects by itself, and only says something is
+  wrong if it stays that way
 
 ## Running it
 
-Everything is one container: the menu pages, the API, the live updates, and the
-drink photos are all served on a single port.
+Barkeep is one container. The menu, the API, the live updates and the drink
+photos are all served on a single port.
 
 ```yaml
 services:
-  home-bar:
-    image: ghcr.io/mtaanquist/home-bar-system:latest
-    container_name: home-bar
+  barkeep:
+    image: ghcr.io/mtaanquist/barkeep:latest
+    container_name: barkeep
     restart: unless-stopped
     init: true
     ports:
@@ -61,65 +71,64 @@ services:
       - ./uploads:/app/uploads
 ```
 
-[`compose.yaml`](compose.yaml) is the same thing with a healthcheck and the
-optional settings included.
+[`compose.yaml`](compose.yaml) is the same with a healthcheck and the optional
+settings filled in.
 
 ```sh
 docker compose up -d
 ```
 
-The port is bound to `127.0.0.1`, so only the machine itself can reach the bar.
-That is deliberate: put a reverse proxy in front to open it up. See
-[Putting a proxy in front](#putting-a-proxy-in-front) below.
+The port is bound to `127.0.0.1`, so only the machine itself can reach Barkeep.
+That is on purpose: put a reverse proxy in front to open it up, as below.
 
-Change the first number if something else on the machine already uses 3000, and
-point the proxy at whatever you chose. The second number is the port inside the
+Change the first number if something on the machine already uses 3000, and
+point the proxy at whatever you chose. The second number is inside the
 container and is better left alone.
 
 Two folders need to survive an upgrade:
 
-| Folder     | Holds                                         |
-| ---------- | --------------------------------------------- |
-| `data/`    | the database, one SQLite file                 |
-| `uploads/` | drink photos                                  |
+| Folder     | Holds                         |
+| ---------- | ----------------------------- |
+| `data/`    | the database, one SQLite file |
+| `uploads/` | drink photos                  |
 
-Back both up together. The database refers to photos by filename.
+Back both up together. The database refers to photos by filename, so they only
+make sense as a pair.
 
-### The first bar
+### Setting up your bar
 
-Open the address in a browser and create a bar. You choose two passwords: one
-for yourself, and one you give to guests. They are the only thing separating
-the two views, which is on purpose for a party.
+Open the address in a browser and create a bar. You pick two passwords: one for
+yourself, and one you give to guests. Those are the only thing between the two
+views, which is about the right amount of security for a party in a garden.
 
-Print the QR code from the settings and guests can reach the menu by pointing a
-camera at it.
+The QR code is in the settings. Show it on a screen, or print it and leave it
+on the bar.
 
 ### Image tags
 
-| Tag                | Built from                                          |
-| ------------------ | --------------------------------------------------- |
-| `latest`           | `main`, which is what the bar should normally run    |
-| `staging`          | the working branch, for trying a change out first    |
-| `v1.2.3`, `v1.2`   | release tags                                         |
-| `sha-abc1234`      | any single build, for pinning to an exact commit     |
+| Tag              | Built from                                     |
+| ---------------- | ---------------------------------------------- |
+| `latest`         | the released version, and what to normally run |
+| `staging`        | the working branch, to try a change out first  |
+| `v1.2.3`, `v1.2` | a specific release                             |
+| `sha-abc1234`    | a single build, to pin to an exact commit      |
 
-Images are built for both Intel and ARM machines, so a Raspberry Pi works as
-well as a NUC.
+Images are built for Intel and ARM, so a Raspberry Pi works as well as a NUC.
 
 ### Settings
 
-All optional. The defaults suit a single container behind a proxy on the same
+All optional. The defaults suit one container behind a proxy on the same
 machine.
 
-| Variable      | Default                | What it does                                                                        |
-| ------------- | ---------------------- | ----------------------------------------------------------------------------------- |
-| `PORT`        | `3000`                 | Port inside the container.                                                            |
-| `DB_PATH`     | `/app/data/bar.db`     | Where the database file lives.                                                        |
-| `UPLOADS_DIR` | `/app/uploads`         | Where drink photos live.                                                              |
-| `PUBLIC_URL`  | taken from the request  | The web address to put in QR codes. Only needed if guests reach the bar on a different address than the one it sees. |
-| `PUID`/`PGID` | unset, runs as root     | Run as an ordinary user instead. Ownership of the two folders is fixed on start.      |
-| `TRUST_PROXY` | this machine and the local network | Which proxies may say what address a guest used. Widening this lets an outsider point QR codes elsewhere. |
-| `TZ`          | `UTC`                  | Which clock "today" is measured against, which matters for the daily figures.         |
+| Variable      | Default                            | What it does                                                                                                      |
+| ------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `PORT`        | `3000`                             | Port inside the container.                                                                                          |
+| `DB_PATH`     | `/app/data/bar.db`                 | Where the database file lives.                                                                                      |
+| `UPLOADS_DIR` | `/app/uploads`                     | Where drink photos live.                                                                                            |
+| `PUBLIC_URL`  | taken from the request             | The address to put in QR codes. Needed only if guests reach Barkeep on a different address than the one it sees.     |
+| `PUID`/`PGID` | unset, runs as root                | Run as an ordinary user instead. Ownership of the two folders is fixed on start.                                    |
+| `TRUST_PROXY` | this machine and the local network | Which proxies may say what address a guest used. Widening this would let an outsider point your QR codes elsewhere. |
+| `TZ`          | `UTC`                              | Which clock "today" is measured against, which decides what counts as today's orders.                               |
 
 ### Putting a proxy in front
 
@@ -131,7 +140,7 @@ bar.example.com {
 }
 ```
 
-Caddy needs nothing else. It passes the live updates through as they are.
+Caddy needs nothing else. It passes the live updates straight through.
 
 If the proxy runs in its own container, share a network with it instead of
 publishing a port at all. Create the network once, outside either stack:
@@ -144,7 +153,7 @@ Then drop the `ports:` block from `compose.yaml` and add:
 
 ```yaml
 services:
-  home-bar:
+  barkeep:
     networks: [edge]
 
 networks:
@@ -152,33 +161,31 @@ networks:
     external: true
 ```
 
-The proxy joins the same network and points at `home-bar:3000`. The bar is then
+The proxy joins the same network and points at `barkeep:3000`. Barkeep is then
 not reachable from outside Docker at all.
 
-### Knowing it is working
+### Checking it is up
 
 The container reports its own health, so `docker ps` and Dockge show whether
-the bar is actually answering rather than merely running. `/api/health` is the
+Barkeep is actually answering rather than merely running. `/api/health` is the
 same check if you want to watch it yourself.
 
 ### Upgrading
 
-Pull the new image and start it. The database is brought up to date on the way
-up, in the same container, so there is nothing to run by hand and nothing left
-sitting in a stopped state afterwards.
+Pull the new image and start it. Any changes to the database are made on the
+way up, inside the same container, so there is nothing to run by hand.
 
-Changes to the database are recorded once they have been applied, along with a
-fingerprint of the file that made them. If one of those files is later edited,
-the bar refuses to start and says which one, rather than running on with the
-database and the code disagreeing.
+Each applied change is recorded with a fingerprint of the file that made it. If
+one of those files is later altered, Barkeep stops and names it rather than
+running on with the database and the code disagreeing.
 
-Photos that no drink refers to are cleared out on start, but only if they are
-more than a day old, so a photo uploaded while someone is still filling in the
-form is left alone.
+Photos no drink refers to are cleared out at startup, but only once they are
+more than a day old, so one uploaded while you are still filling in the form is
+safe.
 
 ## Development
 
-The two halves run separately while developing, with the menu pages proxying
+The two halves run separately while you work on them, with the menu proxying
 `/api` and `/uploads` through to the server.
 
 ```sh
@@ -201,23 +208,22 @@ cd backend  && npm test && npm run lint && npm run typecheck
 cd frontend && npm test && npm run lint && npm run typecheck && npm run build
 ```
 
-Both halves are TypeScript, and the shapes the API sends live in one file
-(`shared/types.d.ts`) that both import, so changing one side without the other
+Both halves are TypeScript. The shapes the API sends live in one file,
+`shared/types.d.ts`, that both import, so changing one side without the other
 is a build error. Both linters fail on a warning.
 
 The tests for the pages run against a stand-in browser, so they need neither a
-server nor a real browser.
+server nor a real one.
 
 ### Changing the database
 
-Add a dated `.sql` file to `backend/src/db/migrations/`. It is applied once, in
-a transaction, on the next start, oldest first. Never edit one that has already
+Add a dated `.sql` file to `backend/src/db/migrations/`. It runs once, inside a
+transaction, on the next start, oldest first. Never edit one that has already
 run; add another instead.
 
-`CLAUDE.md` has the rest of the working notes: how the pieces fit, what the
-tests are for, and what not to commit.
+[`CLAUDE.md`](CLAUDE.md) has the rest of the working notes.
 
-## How it is put together
+## How it is built
 
 ```
 Browser -> :3000 -> /api/*      the API
@@ -228,15 +234,12 @@ Browser -> :3000 -> /api/*      the API
                     SQLite, one file, in data/
 ```
 
-One container on one address. That is the whole shape of it, and it is
-deliberate: an earlier split across separate containers and a proxy kept
-drifting out of step with the code, and three separate bugs came from it.
+One container on one address, which keeps the whole thing small enough to hold
+in your head and leaves nothing to configure between the parts.
 
-Live updates go one way only, from the server to the browser, over a long-lived
-request. The browser reconnects on its own when it drops, which is the main
-reason for doing it this way. The two-way version it replaced had to hand-roll
-reconnection and gave up after three tries, so a phone that slept for a minute
-stopped receiving orders until someone refreshed it.
+Live updates travel one way, from the server to the browser, over a long-lived
+request. The browser handles reconnecting itself, which matters when a phone
+sleeps in someone's pocket halfway through the evening.
 
-SQLite is a good fit here and not something this will outgrow. A party is a
-handful of people ordering drinks over an evening.
+SQLite suits this well. A party is a handful of people ordering drinks over an
+evening, and one file is far easier to back up than a database server.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,125 @@
 # Home Bar System
 
-A small self-hosted bar: guests browse the menu and order drinks, the bartender
-works the queue, and orders update live over WebSockets.
+A small self-hosted bar for a party. Guests pick a drink from a menu on their
+phone, the host works through the orders, and everyone's screen keeps itself up
+to date.
+
+It is meant for a garden bar among friends, not a shop. There are no accounts
+and no payments. A guest types their name, picks a drink, and waits.
+
+## What it does
+
+### For guests
+
+- Browse the menu on a phone, grouped by category or by base spirit
+- See what is available right now; anything out of stock is not offered
+- Mark drinks as favourites, which then appear at the top of the menu
+- Order one drink at a time, and watch it move from ordered to being made to
+  ready
+- Cancel an order, as long as it has not been handed over
+- "Surprise me" picks a drink at random, with a try-again button
+- Look back at what they have had, and order the same again
+- Read the recipe, if the host has chosen to share it for that drink
+
+### For the host
+
+- A queue of orders to accept, mark ready, and mark done, oldest first
+- Optionally accept every order automatically, for when the bar is busy
+- Add drinks with a photo, a recipe, a base spirit, and a short description
+- Crop and reposition a photo so it sits nicely on the card
+- Choose per drink whether guests can read the recipe or only the description
+- Mark a drink as out of stock without deleting it
+- Sort drinks into categories
+- A QR code, to show or print, that takes a guest straight to the bar's menu
+- Simple figures: total orders, orders today, most popular drinks, busiest
+  hours
+
+### Both
+
+- English and Danish, though some of the host's own screens are still English
+  only
+- Screens update on their own as orders come and go, with no refreshing
+- If the connection drops, the browser reconnects by itself. Guests are only
+  told something is wrong if it stays down.
 
 ## Running it
 
-The application ships as a single image on GHCR. Everything — the API, the
-WebSocket endpoint, uploaded images and the frontend — is served from one port.
+Everything is one container: the menu pages, the API, the live updates, and the
+drink photos are all served on a single port.
 
 ```yaml
 services:
   home-bar:
     image: ghcr.io/mtaanquist/home-bar-system:latest
+    container_name: home-bar
     restart: unless-stopped
+    init: true
     ports:
-      - "21000:3000"
+      - "127.0.0.1:21000:3000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
 ```
 
-A complete file with the healthcheck included is in [`compose.yaml`](compose.yaml):
+[`compose.yaml`](compose.yaml) is the same thing with a healthcheck and the
+optional settings included.
 
 ```sh
 docker compose up -d
 ```
 
-Then open <http://localhost:21000>.
+The port is bound to `127.0.0.1`, so only the machine itself can reach the bar.
+That is deliberate: put a reverse proxy in front to open it up. See
+[Putting a proxy in front](#putting-a-proxy-in-front) below.
+
+Two folders need to survive an upgrade:
+
+| Folder     | Holds                                         |
+| ---------- | --------------------------------------------- |
+| `data/`    | the database, one SQLite file                 |
+| `uploads/` | drink photos                                  |
+
+Back both up together. The database refers to photos by filename.
+
+### The first bar
+
+Open the address in a browser and create a bar. You choose two passwords: one
+for yourself, and one you give to guests. They are the only thing separating
+the two views, which is on purpose for a party.
+
+Print the QR code from the settings and guests can reach the menu by pointing a
+camera at it.
 
 ### Image tags
 
-| Tag | Built from |
-| --- | --- |
-| `latest` | `main` — what the bar should normally run |
-| `staging` | `staging` — the working branch, for trying a change on the real host first |
-| `v1.2.3`, `v1.2` | release tags |
-| `sha-abc1234` | any build, for pinning to an exact commit |
+| Tag                | Built from                                          |
+| ------------------ | --------------------------------------------------- |
+| `latest`           | `main`, which is what the bar should normally run    |
+| `staging`          | the working branch, for trying a change out first    |
+| `v1.2.3`, `v1.2`   | release tags                                         |
+| `sha-abc1234`      | any single build, for pinning to an exact commit     |
 
-### Configuration
+Images are built for both Intel and ARM machines, so a Raspberry Pi works as
+well as a NUC.
 
-| Variable      | Default             | Purpose                                                                                                |
-| ------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `PORT`        | `3000`              | Port inside the container.                                                                              |
-| `DB_PATH`     | `/app/data/bar.db`  | SQLite database file.                                                                                   |
-| `UPLOADS_DIR` | `/app/uploads`      | Uploaded drink images.                                                                                  |
-| `PUBLIC_URL`  | derived from request | Base URL baked into guest QR codes. Only needed when guests reach the bar on a different address.       |
-| `PUID`/`PGID` | unset (runs as root) | Run as an unprivileged user. Ownership of the data directories is adjusted on start.                    |
-| `TRUST_PROXY` | private addresses    | Which upstreams may set `X-Forwarded-*`. Accepts Express `trust proxy` values.                          |
-| `TZ`          | `UTC`               | Container timezone.                                                                                     |
+### Settings
 
-### Putting a reverse proxy in front
+All optional. The defaults suit a single container behind a proxy on the same
+machine.
 
-The port is bound to `127.0.0.1`, so only the machine itself can reach the bar.
-A reverse proxy on the same machine is what makes it reachable from outside:
+| Variable      | Default                | What it does                                                                        |
+| ------------- | ---------------------- | ----------------------------------------------------------------------------------- |
+| `PORT`        | `3000`                 | Port inside the container.                                                            |
+| `DB_PATH`     | `/app/data/bar.db`     | Where the database file lives.                                                        |
+| `UPLOADS_DIR` | `/app/uploads`         | Where drink photos live.                                                              |
+| `PUBLIC_URL`  | taken from the request  | The web address to put in QR codes. Only needed if guests reach the bar on a different address than the one it sees. |
+| `PUID`/`PGID` | unset, runs as root     | Run as an ordinary user instead. Ownership of the two folders is fixed on start.      |
+| `TRUST_PROXY` | this machine and the local network | Which proxies may say what address a guest used. Widening this lets an outsider point QR codes elsewhere. |
+| `TZ`          | `UTC`                  | Which clock "today" is measured against, which matters for the daily figures.         |
+
+### Putting a proxy in front
+
+If the proxy runs on the same machine, point it at the published port:
 
 ```caddyfile
 bar.example.com {
@@ -60,17 +127,16 @@ bar.example.com {
 }
 ```
 
-Caddy needs no extra settings — it handles both the live order updates and the
-image files as they are.
+Caddy needs nothing else. It passes the live updates through as they are.
 
-If the proxy runs in its own container instead, share a network with it rather
-than publishing a port. Create the network once:
+If the proxy runs in its own container, share a network with it instead of
+publishing a port at all. Create the network once, outside either stack:
 
 ```sh
 docker network create edge
 ```
 
-Then remove the `ports` block from `compose.yaml` and add:
+Then drop the `ports:` block from `compose.yaml` and add:
 
 ```yaml
 services:
@@ -85,62 +151,88 @@ networks:
 The proxy joins the same network and points at `home-bar:3000`. The bar is then
 not reachable from outside Docker at all.
 
-The container reports health on `/api/health`, so `docker ps` and Dockge show a
-real status rather than just "running".
+### Knowing it is working
 
-### Upgrading from the two-container setup
+The container reports its own health, so `docker ps` and Dockge show whether
+the bar is actually answering rather than merely running. `/api/health` is the
+same check if you want to watch it yourself.
 
-The old layout ran three services: `frontend` (nginx), `backend`, and a one-shot
-`db-init` container that exited as soon as it finished — which is why Dockge
-reported the stack as exited. Migrations now run in-process on every boot, so
-there is no container left behind in a dead state.
+### Upgrading
 
-To move across, keep your `data/` and `uploads/` directories where they are and
-replace the compose file. The database is picked up as-is: migrations are
-tracked by filename in a `migrations` table, already-applied ones are skipped,
-and a database that predates that table is detected and recorded rather than
-re-applied.
+Pull the new image and start it. The database is brought up to date on the way
+up, in the same container, so there is nothing to run by hand and nothing left
+sitting in a stopped state afterwards.
 
-Guests previously reached the frontend on port `21000`, and the new single
-service uses the same host port, so existing bookmarks and QR codes keep
-working. The old `21030` and `21080` mappings are gone — `21080` never had
-anything listening on it.
+Changes to the database are recorded once they have been applied, along with a
+fingerprint of the file that made them. If one of those files is later edited,
+the bar refuses to start and says which one, rather than running on with the
+database and the code disagreeing.
+
+Photos that no drink refers to are cleared out on start, but only if they are
+more than a day old, so a photo uploaded while someone is still filling in the
+form is left alone.
 
 ## Development
 
-The backend and frontend run separately in development, with Vite proxying
-`/api` and `/uploads` to the backend.
+The two halves run separately while developing, with the menu pages proxying
+`/api` and `/uploads` through to the server.
 
 ```sh
 cd backend  && npm install && npm run dev   # http://localhost:3000
 cd frontend && npm install && npm run dev   # http://localhost:5173
 ```
 
-The backend creates `backend/data/bar.db` and `backend/uploads/` on first run
-and applies migrations automatically.
+The server creates `backend/data/bar.db` and `backend/uploads/` on first run.
 
-To build and run the production image from a checkout:
+To build and run the real image from a checkout:
 
 ```sh
 docker compose -f compose.yaml -f compose.dev.yaml up --build
 ```
 
-### Database migrations
+### Checks
 
-Add a date-prefixed `.sql` file to `backend/src/db/migrations/`. It is applied
-once, inside a transaction, on the next start and recorded by filename. Files
-are applied in lexical order, so the date prefix determines ordering.
-
-## Architecture
-
-```
-Browser ──▶ :3000 ──┬─▶ /api/*     Express routes
-                    ├─▶ /ws        WebSocket (same HTTP server)
-                    ├─▶ /uploads/* drink images from disk
-                    └─▶ /*         built frontend, SPA fallback
-
-                       SQLite (WAL) at DB_PATH
+```sh
+cd backend  && npm test && npm run lint && npm run typecheck
+cd frontend && npm test && npm run lint && npm run typecheck && npm run build
 ```
 
-Serving everything from one origin is what lets the frontend use relative `/api`
-and `/ws` paths with no proxy configuration and no CORS.
+Both halves are TypeScript, and the shapes the API sends live in one file
+(`shared/types.d.ts`) that both import, so changing one side without the other
+is a build error. Both linters fail on a warning.
+
+The tests for the pages run against a stand-in browser, so they need neither a
+server nor a real browser.
+
+### Changing the database
+
+Add a dated `.sql` file to `backend/src/db/migrations/`. It is applied once, in
+a transaction, on the next start, oldest first. Never edit one that has already
+run; add another instead.
+
+`CLAUDE.md` has the rest of the working notes: how the pieces fit, what the
+tests are for, and what not to commit.
+
+## How it is put together
+
+```
+Browser -> :3000 -> /api/*      the API
+                    /api/events live updates, server to browser
+                    /uploads/*  drink photos from disk
+                    /*          the menu pages
+
+                    SQLite, one file, in data/
+```
+
+One container on one address. That is the whole shape of it, and it is
+deliberate: an earlier split across separate containers and a proxy kept
+drifting out of step with the code, and three separate bugs came from it.
+
+Live updates go one way only, from the server to the browser, over a long-lived
+request. The browser reconnects on its own when it drops, which is the main
+reason for doing it this way. The two-way version it replaced had to hand-roll
+reconnection and gave up after three tries, so a phone that slept for a minute
+stopped receiving orders until someone refreshed it.
+
+SQLite is a good fit here and not something this will outgrow. A party is a
+handful of people ordering drinks over an evening.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "home-bar-backend",
+  "name": "barkeep-backend",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -11,7 +11,7 @@ import type { Db } from "../src/db/queries.js";
 const tempDirs: string[] = [];
 
 /** A scratch folder that gets cleaned up after the test file finishes. */
-export function makeTempDir(prefix = "home-bar-test-"): string {
+export function makeTempDir(prefix = "barkeep-test-"): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
@@ -44,10 +44,10 @@ export interface TestApp {
 /** The app, wired to a throwaway database and uploads folder. */
 export function makeTestApp(): TestApp {
   const db = makeTestDatabase();
-  const uploadsDir = makeTempDir("home-bar-uploads-");
+  const uploadsDir = makeTempDir("barkeep-uploads-");
   // Pointed at a folder with no web pages in it, so the tests only ever see
   // the API and never the single-page-app catch-all.
-  const frontendDir = makeTempDir("home-bar-frontend-");
+  const frontendDir = makeTempDir("barkeep-frontend-");
 
   return { app: createApp({ db, uploadsDir, frontendDir }), db, uploadsDir };
 }

--- a/backend/tests/migrate.test.ts
+++ b/backend/tests/migrate.test.ts
@@ -126,7 +126,7 @@ describe("migrations", () => {
 describe("noticing an edited migration", () => {
   /** A folder holding just the migrations a test writes into it. */
   const migrationFolder = (files: Record<string, string>): string => {
-    const dir = makeTempDir("home-bar-migrations-");
+    const dir = makeTempDir("barkeep-migrations-");
     for (const [name, sql] of Object.entries(files)) {
       fs.writeFileSync(path.join(dir, name), sql);
     }
@@ -223,7 +223,7 @@ describe("catching up a database that was changed by hand", () => {
 
   it("applies the rest of a migration whose column already exists", () => {
     const db = makeEmptyDatabase();
-    const dir = makeTempDir("home-bar-migrations-");
+    const dir = makeTempDir("barkeep-migrations-");
 
     write(
       dir,
@@ -244,7 +244,7 @@ describe("catching up a database that was changed by hand", () => {
 
   it("stops rather than skip a migration that cannot be run again safely", () => {
     const db = makeEmptyDatabase();
-    const dir = makeTempDir("home-bar-migrations-");
+    const dir = makeTempDir("barkeep-migrations-");
 
     // No "if not exists", so running this a second time is not harmless.
     write(

--- a/backend/tests/routing.test.ts
+++ b/backend/tests/routing.test.ts
@@ -82,7 +82,7 @@ describe("drink photos", () => {
 
 describe("web pages", () => {
   it("sends the app for unknown addresses when pages are bundled", async () => {
-    const frontendDir = makeTempDir("home-bar-frontend-");
+    const frontendDir = makeTempDir("barkeep-frontend-");
     fs.writeFileSync(path.join(frontendDir, "index.html"), "<!doctype html>ok");
 
     const app = createApp({
@@ -98,7 +98,7 @@ describe("web pages", () => {
   });
 
   it("still answers unknown api addresses with an error", async () => {
-    const frontendDir = makeTempDir("home-bar-frontend-");
+    const frontendDir = makeTempDir("barkeep-frontend-");
     fs.writeFileSync(path.join(frontendDir, "index.html"), "<!doctype html>ok");
 
     const app = createApp({

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,9 +1,9 @@
 # Builds the image from this checkout instead of pulling the published one.
 #   docker compose -f compose.yaml -f compose.dev.yaml up --build
 services:
-  home-bar:
+  barkeep:
     build:
       context: .
       dockerfile: Dockerfile
-    image: home-bar-system:local
+    image: barkeep:local
     pull_policy: build

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,9 @@ services:
     init: true
     ports:
       # Everything is served on this one port. Only this machine can reach it,
-      # so put a reverse proxy in front to expose the bar.
-      - "127.0.0.1:21000:3000"
+      # so put a reverse proxy in front to expose the bar. Change the first
+      # number if something else on the machine already uses 3000.
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 services:
-  home-bar:
-    image: ghcr.io/mtaanquist/home-bar-system:latest
-    container_name: home-bar
+  barkeep:
+    image: ghcr.io/mtaanquist/barkeep:latest
+    container_name: barkeep
     restart: unless-stopped
     init: true
     ports:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <title>Home Bar System</title>
+    <title>Barkeep</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "home-bar-frontend",
+  "name": "barkeep-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -76,7 +76,7 @@ const LandingPage: React.FC = () => {
   const getSubtitle = () => {
     switch (mode) {
       case "create":
-        return "Set up your home bar system";
+        return "Set up your bar";
       case "login":
         return "Choose your login type";
       default:
@@ -92,9 +92,9 @@ const LandingPage: React.FC = () => {
         <div className="flex-1 flex items-center justify-center p-12">
           <div className="max-w-lg text-center text-white">
             <h1 className="text-6xl font-bold mb-6">🍸</h1>
-            <h2 className="text-4xl font-bold mb-4">Home Bar System</h2>
+            <h2 className="text-4xl font-bold mb-4">Barkeep</h2>
             <p className="text-xl opacity-90 mb-8">
-              A modern ordering system for your home bar. Create drinks, manage
+              Drinks on tap for your guests. Add what you are pouring, manage
               orders, and serve your guests with style.
             </p>
             <div className="grid grid-cols-2 gap-4 text-sm">
@@ -150,7 +150,7 @@ const LandingPage: React.FC = () => {
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-8 w-full max-w-md transition-colors duration-300">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-2">
-              🍸 Home Bar
+              🍸 Barkeep
             </h1>
             <p className="text-gray-600 dark:text-gray-300">{getSubtitle()}</p>
           </div>

--- a/frontend/src/hooks/useSessionManager.ts
+++ b/frontend/src/hooks/useSessionManager.ts
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useApp } from "../hooks/useApp";
 
 const SESSION_TIMEOUT = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+// Kept under the old name for the same reason as STORAGE_PREFIX.
 export const ACTIVITY_KEY = "homeBarSystem_lastActivity";
 
 export const useSessionManager = () => {

--- a/frontend/src/hooks/useStoredState.ts
+++ b/frontend/src/hooks/useStoredState.ts
@@ -2,6 +2,10 @@ import { useCallback, useState } from "react";
 
 // Everything this app saves in the browser starts with this, so signing out
 // can clear its own things without touching anything else on the site.
+//
+// Deliberately still the old name. Changing it would sign everyone out on
+// upgrade and leave their old settings behind, which nobody would thank us
+// for mid-party. Nobody sees it.
 export const STORAGE_PREFIX = "homeBarSystem_";
 
 /** Blank values are removed rather than saved, so nothing is left behind. */

--- a/frontend/src/pages/PastOrdersPage.tsx
+++ b/frontend/src/pages/PastOrdersPage.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useApp } from "../hooks/useApp";
-import type { Drink, Order } from "../types";
+import { useGuestMenu } from "../hooks/useGuestMenu";
+import type { Drink } from "../types";
 import { useTranslation } from "../utils/translations";
 import { ArrowLeft } from "lucide-react";
 import PastOrders from "../components/PastOrders";
@@ -17,11 +18,14 @@ const PastOrdersPage: React.FC = () => {
     setViewingRecipe,
     setLoading,
     setError,
-    setOrders,
     apiCall,
   } = useApp();
   const t = useTranslation(language);
   const navigate = useNavigate();
+
+  // Loads the menu and the orders. Opening this page directly, or refreshing
+  // it, would otherwise show an empty list.
+  const { refreshOrders } = useGuestMenu();
 
   // Compute the current active order for this customer
   const customerOrder = orders.find(
@@ -51,9 +55,7 @@ const PastOrdersPage: React.FC = () => {
         }),
       });
 
-      // Refresh orders after placing order
-      const updatedOrders = await apiCall<Order[]>(`/orders/bar/${currentBar!.id}`);
-      setOrders(updatedOrders);
+      await refreshOrders();
 
       // Navigate back to customer interface to see the new order
       navigate("/customer");

--- a/frontend/tests/ordering.test.tsx
+++ b/frontend/tests/ordering.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import CustomerInterface from "../src/components/CustomerInterface";
 import RecipeView from "../src/components/RecipeView";
+import PastOrdersPage from "../src/pages/PastOrdersPage";
 import { AppProvider } from "../src/context/AppContext";
 import { LiveUpdatesProvider } from "../src/context/LiveUpdatesContext";
 import {
@@ -177,5 +178,51 @@ describe("looking at a recipe", () => {
     await userEvent.keyboard("{Escape}");
 
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe("the past orders page", () => {
+  const openDirectly = () =>
+    render(
+      <MemoryRouter initialEntries={["/customer/past-orders"]}>
+        <AppProvider>
+          <PastOrdersPage />
+        </AppProvider>
+      </MemoryRouter>
+    );
+
+  // The page used to read whatever the menu had already loaded, so arriving
+  // straight at it, or refreshing, showed nothing.
+  it("loads the orders itself rather than relying on the menu", async () => {
+    orders = [
+      anOrder({ id: 5, status: "processed", drink_id: 1, drink_title: "Negroni" }),
+      anOrder({
+        id: 6,
+        status: "processed",
+        drink_id: 2,
+        drink_title: "Daiquiri",
+      }),
+    ];
+
+    openDirectly();
+
+    // Both come back, even though nothing loaded the menu first.
+    expect(await screen.findAllByText("Negroni")).not.toHaveLength(0);
+    expect(screen.getAllByText("Daiquiri")).not.toHaveLength(0);
+    expect(screen.queryByText(/no past orders/i)).toBeNull();
+  });
+
+  it("shows only this guest's finished orders", async () => {
+    orders = [
+      anOrder({ id: 5, status: "processed", drink_title: "Negroni" }),
+      anOrder({ id: 6, status: "new", drink_title: "Still Coming" }),
+      anOrder({ id: 7, status: "processed", customer_name: "Bob", drink_title: "Someone Elses" }),
+    ];
+
+    openDirectly();
+
+    expect(await screen.findByText("Negroni")).toBeInTheDocument();
+    expect(screen.queryByText("Still Coming")).toBeNull();
+    expect(screen.queryByText("Someone Elses")).toBeNull();
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,11 +16,6 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
-      "/ws": {
-        target: "ws://localhost:3000",
-        ws: true,
-        changeOrigin: true,
-      },
     },
   },
   build: {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@home-bar/shared",
+  "name": "@barkeep/shared",
   "private": true,
   "type": "module",
   "types": "types.d.ts"


### PR DESCRIPTION
Three things: a real bug found by sweeping the app, a README rewrite, and the rename.

## The bug

**The past orders page never loaded anything.** It read whatever the menu had already put into shared state:

| How you get there | Before |
| --- | --- |
| Tapping "Past Orders" from the menu | works |
| Opening the address directly, or a bookmark | empty |
| Refreshing that page | empty |

A guest who refreshed saw "No past orders found" however many drinks they had had. It loads its own orders now. Two tests cover it, and both fail against the old page. This one dates from July 2025, when the page was split out.

## The sweep that found it

67 checks against a copy of the production database, covering every route and the rules behind them: recipe visibility per drink, the order steps and that they cannot be skipped or reversed, who may cancel what, one bar not being able to touch another's data, favourites being per guest, auto-accept, photo cleanup on replace and delete, live updates reaching the right bar and no other, the QR token, and a bar deletion leaving nothing orphaned. Afterwards the database was unchanged at 2 bars, 155 drinks and 36 orders, with the integrity check clean.

Two cosmetic inconsistencies turned up and are **not** fixed, since neither affects anyone using the app:

- A duplicate bar name returns 409, a duplicate category returns 400. Same message either way.
- `/api/bars/999` returns 404, but `/api/drinks/bar/999` returns an empty list.

## The README

It had been describing the app as it was three refactors ago, and much of what remained was an account of what had been wrong and what we did about it, which is no use to a newcomer.

Rewritten as an introduction: what Barkeep is, how an evening actually goes from setting up to serving, then the features split into what guests get and what the host gets. Every setting documented, including `TZ` and `TRUST_PROXY`, which were missing or wrong. No emojis or em dashes. It says plainly that the Danish is incomplete (#46) rather than claiming otherwise.

Also: the example compose file published `21000`, which is one particular host's port rather than a default. Both sides are `3000` now, with a note that the first number is the one to change. A dead `/ws` proxy entry is gone from the dev config; nothing has spoken WebSocket since #38.

## The rename

The repository, the image, the compose service and container, the page title, the landing page, and the three package names are all Barkeep.

**One deliberate exception:** the browser storage prefix stays `homeBarSystem_`. Changing it would sign every guest and the host out on upgrade and strand their saved settings, which is a poor trade for a name nobody ever sees. Both places that define it say so.

### What you need to do on the host

The old `home-bar-system` package keeps every image it already has, so nothing running breaks right now. But once this reaches `main`, new images publish to the new address, and your compose file needs to point at it:

```diff
-    image: ghcr.io/mtaanquist/home-bar-system:latest
+    image: ghcr.io/mtaanquist/barkeep:latest
```

## Checked

109 tests, both linters, both typecheckers, both builds. The renamed image was built and run against a copy of the production database: healthy, page title correct, both bars and all data intact, and the storage prefix confirmed unchanged in the built bundle so nobody gets signed out.