### PR TITLE
Keep a guest's landing-page language choice when they pick a bar

### DIFF
--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -7,8 +7,15 @@ import BarCreator from "./BarCreator";
 import LoginForm from "./LoginForm";
 
 const LandingPage: React.FC = () => {
-  const { currentBar, language, setLanguage, setCurrentBar, setLoginForm } =
-    useApp();
+  const {
+    currentBar,
+    language,
+    languageChosen,
+    setLanguage,
+    setLanguageChosen,
+    setCurrentBar,
+    setLoginForm,
+  } = useApp();
   const t = useTranslation(language);
 
   const [mode, setMode] = useState<"select" | "create" | "login">("select");
@@ -17,7 +24,8 @@ const LandingPage: React.FC = () => {
   const handleSelectBar = (bar: Bar) => {
     setSelectedBar(bar);
     setCurrentBar(bar);
-    setLanguage(bar.language);
+    // A guest who picked a language keeps it; otherwise fall back to the bar's.
+    if (!languageChosen) setLanguage(bar.language);
     setMode("login");
   };
 
@@ -86,7 +94,10 @@ const LandingPage: React.FC = () => {
 
   const languageOption = (value: Language, label: string) => (
     <button
-      onClick={() => setLanguage(value)}
+      onClick={() => {
+        setLanguage(value);
+        setLanguageChosen(true);
+      }}
       aria-pressed={language === value}
       className={`h-11 px-4 text-label transition-colors duration-(--duration-instant) cursor-pointer ${
         language === value

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -27,6 +27,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
   );
   const [customerName, setCustomerName] = useStoredState("customerName", "");
   const [language, setLanguage] = useStoredState<Language>("language", "en");
+  // Whether the guest picked a language by hand. Once they have, picking a bar
+  // must not quietly switch it back to the bar's default.
+  const [languageChosen, setLanguageChosen] = useStoredState<boolean>(
+    "languageChosen",
+    false
+  );
 
   // Loading and error states
   const [loading, setLoading] = useState(false);
@@ -57,6 +63,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setCurrentBar(null);
     setCustomerName("");
     setLanguage("en");
+    setLanguageChosen(false);
     setBarForm({
       name: "",
       bartenderPassword: "",
@@ -66,7 +73,13 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setLoginForm({ password: "", name: "" });
 
     clearStoredState();
-  }, [setUserType, setCurrentBar, setCustomerName, setLanguage]);
+  }, [
+    setUserType,
+    setCurrentBar,
+    setCustomerName,
+    setLanguage,
+    setLanguageChosen,
+  ]);
 
   // Session validation effect
   useEffect(() => {
@@ -118,6 +131,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     currentBar,
     customerName,
     language,
+    languageChosen,
 
     // Loading and error states
     loading,
@@ -142,6 +156,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setCurrentBar,
     setCustomerName,
     setLanguage,
+    setLanguageChosen,
     setLoading,
     setError,
     setBarForm,

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -26,6 +26,7 @@ export interface AppContextType {
   currentBar: Bar | null;
   customerName: string;
   language: Language;
+  languageChosen: boolean;
 
   // Loading and error states
   loading: boolean;
@@ -50,6 +51,7 @@ export interface AppContextType {
   setCurrentBar: (bar: Bar | null) => void;
   setCustomerName: (name: string) => void;
   setLanguage: (lang: Language) => void;
+  setLanguageChosen: (chosen: boolean) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
   setBarForm: React.Dispatch<React.SetStateAction<BarForm>>;

--- a/frontend/tests/language.test.tsx
+++ b/frontend/tests/language.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import App from "../src/App";
+import { aBar, fakeApi, FakeEventSource } from "./helpers";
+
+const LANGUAGE_KEY = "homeBarSystem_language";
+
+/** Serves the bar list a guest sees on the landing page. */
+const serve = (bar = aBar()) =>
+  fakeApi((path) => {
+    if (path === "/api/bars") return [bar];
+    if (path.includes("/bars/1")) return bar;
+    return undefined;
+  });
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+  window.history.pushState({}, "", "/");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+  window.history.pushState({}, "", "/");
+});
+
+describe("choosing a language on the landing page", () => {
+  // The bug: picking a bar used to overwrite the guest's choice with the bar's
+  // own language (usually English), so Dansk was lost the moment they moved on.
+  it("keeps the guest's Dansk choice when they pick an English bar", async () => {
+    serve(aBar({ language: "en" }));
+    render(<App />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Dansk" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /The Spotted Cow/ })
+    );
+
+    // The login screen is now in Danish, and stays that way.
+    expect(
+      await screen.findByRole("button", { name: "Gæst login" })
+    ).toBeTruthy();
+    expect(JSON.parse(localStorage.getItem(LANGUAGE_KEY) ?? '""')).toBe("da");
+  });
+
+  // A guest who never touches the toggle still gets the bar's own language.
+  it("falls back to the bar's language when the guest has not chosen", async () => {
+    serve(aBar({ language: "da" }));
+    render(<App />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /The Spotted Cow/ })
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Gæst login" })
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What was wrong

Switching the landing page to Dansk worked on screen, but the moment a guest
picked a bar to log into, the language snapped back to English and stayed there.

The choice was never actually lost from storage — it's saved to the browser and
survives navigation. The problem was that selecting a bar **overwrote** it:
`handleSelectBar` in `LandingPage.tsx` unconditionally ran
`setLanguage(bar.language)`, replacing the guest's manual choice with the bar's
configured language (almost always `"en"`) and persisting that over it.

## The fix

Remember when a guest picks a language by hand, and only fall back to the bar's
language when they haven't:

- Added a persisted `languageChosen` flag in `AppContext`, stored the same way
  `language` already is (`useStoredState`), so the choice survives a refresh on
  the landing page too.
- The landing-page toggle marks the choice as made on click.
- `handleSelectBar` now applies the bar's language only when the guest hasn't
  chosen one.
- The flag is cleared on sign-out, so the next guest on a shared phone starts
  fresh.

A guest who never touches the toggle still gets the bar's configured language,
exactly as before.

## Out of scope

`setLanguage(bar.language)` is also called when scanning a bar's QR code, when a
bartender saves the bar's language in settings, and when creating a bar. Those
are deliberate entry points where applying the bar's language is intended and no
manual landing-page choice precedes them, so they're left unchanged.

## Tests

- New regression test `frontend/tests/language.test.tsx`: choosing Dansk then
  picking an English bar keeps the login screen in Danish (and the stored
  language stays `"da"`). Confirmed it fails against the old behaviour. A
  companion test checks the bar default still applies for guests who don't
  choose.
- Full frontend suite: **90 tests pass**, lint clean, typecheck clean, build
  succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYCz7ipZRTmriDv8pyKBEs)_