### PR TITLE
Issue signed session cookies on sign-in (#53, part 1 of 3)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import {
   type TrustProxy,
 } from "./config.js";
 import { errorReply, route } from "./http.js";
+import { attachSession } from "./auth/middleware.js";
 import { createRealtime } from "./realtime.js";
 import type { Db } from "./db/queries.js";
 
@@ -59,6 +60,9 @@ export function createApp({
 
   app.use(express.json({ limit: "10mb" }));
   app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+
+  // Reads the sign-in cookie, if any, before the routes and the live feed run.
+  app.use(attachSession);
 
   if (requestLogging) {
     app.use((req, _res, next) => {

--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -1,0 +1,36 @@
+import type { NextFunction, Request, Response } from "express";
+
+import {
+  readSessionCookie,
+  verifySession,
+  type Session,
+} from "./session.js";
+
+/**
+ * Resolves the cookie to a session and leaves it on `res.locals` for routes to
+ * read. It never turns anyone away — each route decides what it needs. Runs
+ * before the routes so the live feed sees it too.
+ */
+export function attachSession(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const token = readSessionCookie(req);
+  const payload = token ? verifySession(token) : null;
+
+  if (payload) {
+    res.locals["session"] = {
+      barId: payload.barId,
+      role: payload.role,
+      ...(payload.name !== undefined ? { name: payload.name } : {}),
+    } satisfies Session;
+  }
+
+  next();
+}
+
+/** The session on this reply, if the cookie checked out. */
+export function currentSession(res: Response): Session | undefined {
+  return res.locals["session"] as Session | undefined;
+}

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -1,0 +1,165 @@
+import fs from "fs";
+import path from "path";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { Request, Response } from "express";
+
+import type { UserType } from "../../../shared/types.js";
+import {
+  COOKIE_SECURE,
+  NODE_ENV,
+  SESSION_SECRET,
+  SESSION_SECRET_FILE,
+  SESSION_TTL_MS,
+} from "../config.js";
+
+/** Who someone is, once their cookie has been checked. */
+export interface Session {
+  barId: number;
+  role: UserType;
+  /** A guest's name, so an order can't be placed or cancelled as someone else. */
+  name?: string;
+}
+
+/** The signed contents of a cookie: a session, plus when it was made and dies. */
+export interface SessionPayload extends Session {
+  v: 1;
+  iat: number;
+  exp: number;
+}
+
+/** The one cookie we set. */
+const COOKIE_NAME = "session";
+
+let cachedSecret: string | undefined;
+
+/**
+ * The signing key. Prefer the environment; in tests keep one in memory so no
+ * file is written; otherwise keep a generated one on disk so a restart doesn't
+ * sign everybody out.
+ */
+function secret(): string {
+  if (cachedSecret !== undefined) return cachedSecret;
+
+  if (SESSION_SECRET) {
+    cachedSecret = SESSION_SECRET;
+  } else if (NODE_ENV === "test") {
+    cachedSecret = randomBytes(32).toString("hex");
+  } else {
+    cachedSecret = readOrCreateSecretFile();
+  }
+
+  return cachedSecret;
+}
+
+function readOrCreateSecretFile(): string {
+  try {
+    const existing = fs.readFileSync(SESSION_SECRET_FILE, "utf8").trim();
+    if (existing) return existing;
+  } catch {
+    // Not there the first time; made below.
+  }
+
+  const fresh = randomBytes(32).toString("hex");
+  fs.mkdirSync(path.dirname(SESSION_SECRET_FILE), { recursive: true });
+  // Owner-only: nobody else on the box should read the signing key.
+  fs.writeFileSync(SESSION_SECRET_FILE, fresh, { mode: 0o600 });
+  return fresh;
+}
+
+function sign(body: string): string {
+  return createHmac("sha256", secret()).update(body).digest("base64url");
+}
+
+/** Turns a session into a signed cookie value. */
+export function signSession(session: Session, now: number = Date.now()): string {
+  const payload: SessionPayload = {
+    v: 1,
+    barId: session.barId,
+    role: session.role,
+    // Only carry a name when there is one — the type won't take undefined.
+    ...(session.name !== undefined ? { name: session.name } : {}),
+    iat: now,
+    exp: now + SESSION_TTL_MS,
+  };
+
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${body}.${sign(body)}`;
+}
+
+function isSessionPayload(value: unknown, now: number): value is SessionPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const p = value as Record<string, unknown>;
+
+  return (
+    p["v"] === 1 &&
+    typeof p["barId"] === "number" &&
+    (p["role"] === "bartender" || p["role"] === "guest") &&
+    typeof p["iat"] === "number" &&
+    typeof p["exp"] === "number" &&
+    p["exp"] > now &&
+    (p["name"] === undefined || typeof p["name"] === "string")
+  );
+}
+
+/** A cookie value back to a session, or null if it's forged, spoiled or old. */
+export function verifySession(
+  token: string,
+  now: number = Date.now()
+): SessionPayload | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+
+  const body = token.slice(0, dot);
+  const given = Buffer.from(token.slice(dot + 1));
+  const wanted = Buffer.from(sign(body));
+
+  // Same length first, then a constant-time compare so timing gives nothing away.
+  if (given.length !== wanted.length || !timingSafeEqual(given, wanted)) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  return isSessionPayload(parsed, now) ? parsed : null;
+}
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: "lax",
+  secure: COOKIE_SECURE,
+  path: "/",
+} as const;
+
+/** Sends the signed cookie back on a reply. */
+export function setSessionCookie(res: Response, session: Session): void {
+  res.cookie(COOKIE_NAME, signSession(session), {
+    ...COOKIE_OPTIONS,
+    maxAge: SESSION_TTL_MS,
+  });
+}
+
+/** Clears it, on sign-out. */
+export function clearSessionCookie(res: Response): void {
+  res.clearCookie(COOKIE_NAME, COOKIE_OPTIONS);
+}
+
+/** Reads our cookie out of the request, if it's there. */
+export function readSessionCookie(req: Request): string | undefined {
+  const header = req.headers.cookie;
+  if (!header) return undefined;
+
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === COOKIE_NAME) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+
+  return undefined;
+}

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -51,3 +51,24 @@ export const TRUST_PROXY: TrustProxy = (() => {
   if (/^\d+$/.test(raw)) return Number(raw);
   return raw;
 })();
+
+// How long a sign-in lasts. The bartender screen sits on a counter all night,
+// so a whole day rather than a short idle window.
+export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+// The key that signs sign-in cookies. Set SESSION_SECRET so it stays the same
+// across restarts (and across several servers). Left unset, the server keeps a
+// generated one in a file next to the database — see auth/session.ts.
+export const SESSION_SECRET: string | undefined =
+  process.env.SESSION_SECRET || undefined;
+
+// Where that generated key is kept when SESSION_SECRET is unset: next to the
+// database, on the folder that already survives an upgrade.
+export const SESSION_SECRET_FILE = path.join(
+  path.dirname(DB_PATH),
+  ".session-secret"
+);
+
+// Only send the cookie over HTTPS when the public address is HTTPS. Plain-http
+// development has to work without it, or the cookie never arrives.
+export const COOKIE_SECURE: boolean = PUBLIC_URL.startsWith("https://");

--- a/backend/src/http.ts
+++ b/backend/src/http.ts
@@ -21,6 +21,16 @@ export class HttpError extends Error {
   static conflict(message: string): HttpError {
     return new HttpError(409, message);
   }
+
+  /** Not signed in — no cookie, or one that no longer holds up. */
+  static unauthorized(message: string): HttpError {
+    return new HttpError(401, message);
+  }
+
+  /** Signed in, but not as someone allowed to do this. */
+  static forbidden(message: string): HttpError {
+    return new HttpError(403, message);
+  }
 }
 
 /**

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -4,6 +4,11 @@ import bcrypt from "bcrypt";
 import type { SignedIn, UserType } from "../../../shared/types.js";
 import { HttpError, requireId, requireText, route } from "../http.js";
 import {
+  clearSessionCookie,
+  setSessionCookie,
+} from "../auth/session.js";
+import { currentSession } from "../auth/middleware.js";
+import {
   findBar,
   publicBar,
   run,
@@ -45,6 +50,7 @@ export default function createAuthRoutes(db: Db): Router {
     "/bartender",
     route(async (req, res) => {
       const bar = await signIn(req.body, "bartender");
+      setSessionCookie(res, { barId: bar.id, role: "bartender" });
 
       // The bartender arriving is the bar opening. Last night's closing —
       // whether it was the switch or the time — is cleared, so nobody has
@@ -70,19 +76,37 @@ export default function createAuthRoutes(db: Db): Router {
         label: "Customer name",
       });
       const bar = await signIn(req.body, "guest");
+      setSessionCookie(res, { barId: bar.id, role: "guest", name: customerName });
 
       res.json({ ...signedInAs(bar, "guest"), customerName });
     })
   );
 
-  router.post(
-    "/verify",
-    route((req, res) => {
-      const barId = requireId(req.body, "barId");
-      const userType = requireText(req.body, "userType");
-      const bar = findBar(db, barId);
+  // Who the cookie says you are. Replaces the old /verify, which took your word
+  // for it and checked nothing.
+  router.get(
+    "/me",
+    route((_req, res) => {
+      const session = currentSession(res);
+      if (!session) throw HttpError.unauthorized("Not signed in");
 
-      res.json(signedInAs(bar, userType as UserType));
+      const bar = findBar(db, session.barId);
+      const reply = signedInAs(bar, session.role);
+
+      res.json(
+        session.role === "guest" && session.name
+          ? { ...reply, customerName: session.name }
+          : reply
+      );
+    })
+  );
+
+  // Sign out: drop the cookie.
+  router.post(
+    "/logout",
+    route((_req, res) => {
+      clearSessionCookie(res);
+      res.json({ success: true });
     })
   );
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -18,6 +18,7 @@ import {
   toFlag,
   wasSent,
 } from "../http.js";
+import { setSessionCookie } from "../auth/session.js";
 import {
   all,
   buildUpdate,
@@ -138,9 +139,14 @@ export default function createBarRoutes({
         language
       );
 
+      const bar = findBar(db, Number(lastInsertRowid));
+      // Making a bar signs you in as its bartender, so there's no unguarded
+      // gap between creating it and being able to run it.
+      setSessionCookie(res, { barId: bar.id, role: "bartender" });
+
       // The whole bar goes back, settings and all, so the pages can hold on to
       // it as-is.
-      res.status(201).json(publicBar(findBar(db, Number(lastInsertRowid))));
+      res.status(201).json(publicBar(bar));
     })
   );
 
@@ -359,6 +365,9 @@ export default function createBarRoutes({
       if (token !== guestToken(bar)) {
         throw new HttpError(401, "Invalid or expired token");
       }
+
+      // The QR link gets you a session; it isn't one itself.
+      setSessionCookie(res, { barId: bar.id, role: "guest", name: customerName });
 
       res.json({
         success: true,

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -6,7 +6,9 @@ import type { Express } from "express";
 
 import { openDatabase } from "../src/db/index.js";
 import { createApp } from "../src/app.js";
+import { signSession } from "../src/auth/session.js";
 import type { Db } from "../src/db/queries.js";
+import type { UserType } from "../../shared/types.js";
 
 const tempDirs: string[] = [];
 
@@ -74,4 +76,16 @@ export function seedBar(db: Db, { name = "Test Bar" } = {}): SeededBar {
     .run(barId);
 
   return { barId, drinkId: Number(drink.lastInsertRowid) };
+}
+
+/**
+ * A Cookie header carrying a signed session, so a test can act as a bartender
+ * or a guest without going through a password.
+ */
+export function sessionCookie(session: {
+  barId: number;
+  role: UserType;
+  name?: string;
+}): string {
+  return `session=${signSession(session)}`;
 }

--- a/backend/tests/session.test.ts
+++ b/backend/tests/session.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+
+import {
+  makeTestApp,
+  seedBar,
+  sessionCookie,
+  cleanUpTempDirs,
+} from "./helpers.js";
+import { signSession, verifySession } from "../src/auth/session.js";
+
+afterAll(cleanUpTempDirs);
+
+// The token is what the whole scheme rests on: it has to survive a round trip
+// and fall over the moment it's tampered with or out of date.
+describe("session tokens", () => {
+  it("signs a token it can read back", () => {
+    const token = signSession({ barId: 7, role: "bartender" });
+    expect(verifySession(token)).toMatchObject({ barId: 7, role: "bartender" });
+  });
+
+  it("carries a guest's name", () => {
+    const token = signSession({ barId: 1, role: "guest", name: "Ada" });
+    expect(verifySession(token)?.name).toBe("Ada");
+  });
+
+  it("turns down a tampered token", () => {
+    const token = signSession({ barId: 1, role: "bartender" });
+    const tampered = token.slice(0, -1) + (token.endsWith("A") ? "B" : "A");
+    expect(verifySession(tampered)).toBeNull();
+  });
+
+  it("turns down an expired token", () => {
+    // Signed as if long ago, so its expiry is already in the past.
+    const token = signSession({ barId: 1, role: "bartender" }, 1000);
+    expect(verifySession(token)).toBeNull();
+  });
+
+  it("turns down nonsense", () => {
+    expect(verifySession("")).toBeNull();
+    expect(verifySession("not-a-token")).toBeNull();
+    expect(verifySession("a.b")).toBeNull();
+  });
+});
+
+describe("the sign-in cookie", () => {
+  it("is set, HttpOnly and Lax, when a bartender signs in", async () => {
+    const { app } = makeTestApp();
+    const created = await request(app).post("/api/bars").send({
+      name: "Cookie Bar",
+      bartenderPassword: "shaker",
+      guestPassword: "gin",
+    });
+
+    const res = await request(app)
+      .post("/api/auth/bartender")
+      .send({ barId: created.body.id, password: "shaker" });
+
+    expect(res.status).toBe(200);
+    const cookie = res.headers["set-cookie"]?.[0] ?? "";
+    expect(cookie).toMatch(/^session=/);
+    expect(cookie).toMatch(/HttpOnly/i);
+    expect(cookie).toMatch(/SameSite=Lax/i);
+  });
+
+  it("is set when a bar is created", async () => {
+    const { app } = makeTestApp();
+    const res = await request(app).post("/api/bars").send({
+      name: "Fresh Bar",
+      bartenderPassword: "shaker",
+      guestPassword: "gin",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.headers["set-cookie"]?.[0] ?? "").toMatch(/^session=/);
+  });
+});
+
+describe("GET /api/auth/me", () => {
+  it("reports the bartender the cookie names", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      userType: "bartender",
+      bar: { id: barId },
+    });
+  });
+
+  it("gives a guest their name back", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Ada" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ userType: "guest", customerName: "Ada" });
+  });
+
+  it("never leaks the stored passwords", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }));
+
+    expect(JSON.stringify(res.body)).not.toMatch(/password_hash|guest_token/);
+  });
+
+  it("turns away a request with no cookie", async () => {
+    const { app } = makeTestApp();
+    const res = await request(app).get("/api/auth/me");
+    expect(res.status).toBe(401);
+  });
+
+  it("turns away a forged cookie", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Cookie", `session=${barId}.forged`);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/auth/logout", () => {
+  it("clears the cookie", async () => {
+    const { app } = makeTestApp();
+    const res = await request(app).post("/api/auth/logout");
+
+    expect(res.status).toBe(200);
+    const cookie = res.headers["set-cookie"]?.[0] ?? "";
+    expect(cookie).toMatch(/^session=/);
+    // A cleared cookie is one with an expiry already gone by.
+    expect(cookie).toMatch(/Expires=Thu, 01 Jan 1970/i);
+  });
+});

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -97,7 +97,10 @@ export interface Favourite {
   created_at: string;
 }
 
-/** The reply to signing in, or to checking a session is still good. */
+/**
+ * The reply to signing in, and to `GET /api/auth/me`, which reads the cookie
+ * back to say who is signed in (or answers 401 with `ApiError`).
+ */
 export interface SignedIn {
   success: true;
   userType: UserType;


### PR DESCRIPTION
Part 1 of 3 towards real authentication (#53). This lays the session
groundwork **without enforcing anything yet**, so everything that works today
keeps working — all 104 backend tests pass, lint, typecheck and the production
build are green.

## Why

The API has no sessions. Signing in checks a password once and the browser
remembers who it is on its own; `POST /api/auth/verify` took your word for who
you were and checked nothing. Before we can lock down the 21 mutating routes
(part 2) we need something real to check.

## What's in this part

- **A signed, self-expiring token** (HMAC over a small `{barId, role, name?}`
  payload) in an `HttpOnly`, `SameSite=Lax` cookie, `Secure` when the public
  address is HTTPS. The signing key comes from `SESSION_SECRET`, or a generated
  file kept next to the database so a restart doesn't sign everyone out.
  `backend/src/auth/session.ts`.
- **`attachSession`** reads the cookie before the routes and the live feed run
  and leaves the session on `res.locals`. It never turns anyone away — each
  route decides what it needs in part 2. `backend/src/auth/middleware.ts`.
- **Sign-in issues the cookie.** Bartender and guest sign-in set it; creating a
  bar signs you in as its bartender; the guest QR link now *exchanges for* a
  session rather than being one. Guest sessions carry the guest's name.
- **Real session read-back.** The fake `POST /api/auth/verify` is replaced by
  `GET /api/auth/me` (reads the cookie back, or 401), plus `POST /api/auth/logout`.
- `HttpError` gains 401/403 factories; a `sessionCookie()` test helper mints a
  cookie without a password. New tests cover signing, tampering, expiry, `/me`
  and `/logout`.

## What's deliberately not here

- **No enforcement.** The 21 mutating routes and `/api/events` are locked down
  in **part 2**, where the acting bar comes from the token instead of the
  request body.
- **Frontend untouched.** It moves off `localStorage` to `GET /api/auth/me` in
  **part 3**. The only shared-types change here is a comment.

## Notes for review

- Session length is 24h for now. A follow-up (#56) proposes splitting that by
  role so guests get a longer-lived cookie; out of scope here.
- The generated signing-key file lives next to the database (the folder that
  already survives an upgrade) and is written owner-only. Set `SESSION_SECRET`
  in production to keep it stable across several servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_