### PR TITLE
Require a session for every change and the live feed (#53, part 2 of 3)

### DIFF
--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 
+import { HttpError } from "../http.js";
 import {
   readSessionCookie,
   verifySession,
@@ -33,4 +34,32 @@ export function attachSession(
 /** The session on this reply, if the cookie checked out. */
 export function currentSession(res: Response): Session | undefined {
   return res.locals["session"] as Session | undefined;
+}
+
+/** Whoever the cookie names, of either kind. Throws if there's no session. */
+export function requireSession(res: Response): Session {
+  const session = currentSession(res);
+  if (!session) throw HttpError.unauthorized("Please sign in");
+  return session;
+}
+
+/**
+ * A bartender, and the bar they're signed in to. The bar comes from the cookie,
+ * so a request can't act on a bar it wasn't signed in to by naming another one.
+ */
+export function requireBartender(res: Response): { barId: number } {
+  const session = requireSession(res);
+  if (session.role !== "bartender") {
+    throw HttpError.forbidden("Only the bartender can do this");
+  }
+  return { barId: session.barId };
+}
+
+/** A guest, their bar, and their name — both taken from the cookie. */
+export function requireGuest(res: Response): { barId: number; name: string } {
+  const session = requireSession(res);
+  if (session.role !== "guest" || !session.name) {
+    throw HttpError.forbidden("Only a guest can do this");
+  }
+  return { barId: session.barId, name: session.name };
 }

--- a/backend/src/realtime.ts
+++ b/backend/src/realtime.ts
@@ -6,6 +6,7 @@
 
 import type { Request, Response } from "express";
 import type { LiveUpdate } from "../../shared/types.js";
+import { currentSession } from "./auth/middleware.js";
 
 const KEEPALIVE_MS = 25000;
 
@@ -41,12 +42,16 @@ export function createRealtime(): Realtime {
   const clients = new Set<Listener>();
 
   function subscribe(req: Request, res: Response): void {
-    const barId = Number(req.query["barId"]);
+    // The bar comes from the cookie, so a browser only ever watches the bar it
+    // signed in to — no listening in on another by changing the address.
+    const session = currentSession(res);
 
-    if (!Number.isInteger(barId) || barId <= 0) {
-      res.status(400).json({ error: "A bar id is required" });
+    if (!session) {
+      res.status(401).json({ error: "Please sign in" });
       return;
     }
+
+    const barId = session.barId;
 
     res.writeHead(200, {
       "Content-Type": "text/event-stream",

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -1,4 +1,8 @@
-import express, { type Router } from "express";
+import express, {
+  type Request,
+  type Response,
+  type Router,
+} from "express";
 import bcrypt from "bcrypt";
 import QRCode from "qrcode";
 import { randomBytes } from "node:crypto";
@@ -19,6 +23,7 @@ import {
   wasSent,
 } from "../http.js";
 import { setSessionCookie } from "../auth/session.js";
+import { requireBartender } from "../auth/middleware.js";
 import {
   all,
   buildUpdate,
@@ -84,6 +89,19 @@ function originalToken(barId: number): string {
 /** What this bar's QR code carries today. */
 function guestToken(bar: BarRow): string {
   return bar.guest_token || originalToken(bar.id);
+}
+
+/**
+ * The bar the signed-in bartender may change: their own. The bar comes from
+ * the cookie, and the address has to name the same one, so a valid sign-in for
+ * one bar can't reach another.
+ */
+function ownBar(req: Request, res: Response): number {
+  const { barId } = requireBartender(res);
+  if (idParam(req, "id") !== barId) {
+    throw HttpError.forbidden("You can only change your own bar");
+  }
+  return barId;
 }
 
 interface BarRoutesOptions {
@@ -175,7 +193,7 @@ export default function createBarRoutes({
   router.put(
     "/:id",
     route(async (req, res) => {
-      const barId = idParam(req, "id");
+      const barId = ownBar(req, res);
       findBar(db, barId);
 
       const body = req.body as Record<string, unknown>;
@@ -285,7 +303,7 @@ export default function createBarRoutes({
   router.delete(
     "/:id",
     route((req, res) => {
-      const barId = idParam(req, "id");
+      const barId = ownBar(req, res);
       const bar = findBar(db, barId);
 
       // Everything below the bar goes with it, so make it deliberate.
@@ -310,7 +328,7 @@ export default function createBarRoutes({
   router.post(
     "/:id/rotate-guest-link",
     route((req, res) => {
-      const barId = idParam(req, "id");
+      const barId = ownBar(req, res);
       findBar(db, barId);
 
       run(

--- a/backend/src/routes/categories.ts
+++ b/backend/src/routes/categories.ts
@@ -1,8 +1,9 @@
 import express, { type Router } from "express";
 
 import type { Category } from "../../../shared/types.js";
-import { HttpError, idParam, requireId, requireText, route } from "../http.js";
+import { HttpError, idParam, requireText, route } from "../http.js";
 import { all, count, findCategory, one, run, type Db } from "../db/queries.js";
+import { requireBartender } from "../auth/middleware.js";
 
 export default function createCategoryRoutes(db: Db): Router {
   const router = express.Router();
@@ -25,7 +26,7 @@ export default function createCategoryRoutes(db: Db): Router {
   router.post(
     "/",
     route((req, res) => {
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
       const name = requireText(req.body, "name");
 
       const taken = one<Pick<Category, "id">>(
@@ -54,7 +55,7 @@ export default function createCategoryRoutes(db: Db): Router {
     "/:id",
     route((req, res) => {
       const categoryId = idParam(req, "id");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
       const name = requireText(req.body, "name");
 
       findCategory(db, categoryId, barId);
@@ -85,7 +86,7 @@ export default function createCategoryRoutes(db: Db): Router {
     "/:id",
     route((req, res) => {
       const categoryId = idParam(req, "id");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
 
       findCategory(db, categoryId, barId);
 

--- a/backend/src/routes/drinks.ts
+++ b/backend/src/routes/drinks.ts
@@ -28,6 +28,7 @@ import {
   run,
   type Db,
 } from "../db/queries.js";
+import { requireBartender, requireGuest } from "../auth/middleware.js";
 import { deletePhotoIfUnused } from "../uploads.js";
 
 const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
@@ -141,6 +142,7 @@ export default function createDrinkRoutes({
     "/upload-image",
     upload.single("image"),
     route((req, res) => {
+      requireBartender(res);
       if (!req.file) throw HttpError.badRequest("No image file provided");
 
       res.json({
@@ -154,7 +156,7 @@ export default function createDrinkRoutes({
   router.post(
     "/",
     route((req, res) => {
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
       const title = requireText(req.body, "title");
       const recipe = requireText(req.body, "recipe");
 
@@ -192,7 +194,7 @@ export default function createDrinkRoutes({
     "/:drinkId",
     route((req, res) => {
       const drinkId = idParam(req, "drinkId");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
 
       const existing = findDrink(db, drinkId, barId);
 
@@ -231,7 +233,7 @@ export default function createDrinkRoutes({
     "/:drinkId/stock",
     route((req, res) => {
       const drinkId = idParam(req, "drinkId");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
 
       const drink = findDrink(db, drinkId, barId);
 
@@ -251,7 +253,7 @@ export default function createDrinkRoutes({
     "/:drinkId",
     route((req, res) => {
       const drinkId = idParam(req, "drinkId");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
 
       const drink = findDrink(db, drinkId, barId);
 
@@ -322,9 +324,8 @@ export default function createDrinkRoutes({
   router.post(
     "/bar/:barId/favourites",
     route((req, res) => {
-      const barId = idParam(req, "barId");
+      const { barId, name } = requireGuest(res);
       const drinkId = requireId(req.body, "drinkId");
-      const customerName = requireText(req.body, "customerName");
 
       findDrink(db, drinkId, barId);
 
@@ -333,7 +334,7 @@ export default function createDrinkRoutes({
         `INSERT OR IGNORE INTO user_favourites (bar_id, customer_name, drink_id)
          VALUES (?, ?, ?)`,
         barId,
-        customerName,
+        name,
         drinkId
       );
 
@@ -350,16 +351,15 @@ export default function createDrinkRoutes({
   router.delete(
     "/bar/:barId/favourites",
     route((req, res) => {
-      const barId = idParam(req, "barId");
+      const { barId, name } = requireGuest(res);
       const drinkId = requireId(req.body, "drinkId");
-      const customerName = requireText(req.body, "customerName");
 
       const { changes } = run(
         db,
         `DELETE FROM user_favourites
          WHERE bar_id = ? AND customer_name = ? AND drink_id = ?`,
         barId,
-        customerName,
+        name,
         drinkId
       );
 

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -9,7 +9,6 @@ import type {
 import {
   HttpError,
   idParam,
-  optionalText,
   requireId,
   requireText,
   route,
@@ -24,6 +23,11 @@ import {
   run,
   type Db,
 } from "../db/queries.js";
+import {
+  requireBartender,
+  requireGuest,
+  requireSession,
+} from "../auth/middleware.js";
 import { liveUpdates } from "../realtime.js";
 import { assertCanMove, isOrderStatus, OPEN_STATUSES } from "../orders/status.js";
 import { ordersAreClosed } from "../orders/closing.js";
@@ -117,9 +121,10 @@ export default function createOrderRoutes(db: Db): Router {
   router.post(
     "/",
     route((req, res) => {
-      const barId = requireId(req.body, "barId");
+      // The name on the order is the one the guest signed in with, so nobody
+      // can order under someone else's name.
+      const { barId, name: customerName } = requireGuest(res);
       const drinkId = requireId(req.body, "drinkId");
-      const customerName = requireText(req.body, "customerName");
       const drinkTitle = requireText(req.body, "drinkTitle");
 
       const bar = findBar(db, barId);
@@ -173,7 +178,7 @@ export default function createOrderRoutes(db: Db): Router {
     "/:orderId/status",
     route((req, res) => {
       const orderId = idParam(req, "orderId");
-      const barId = requireId(req.body, "barId");
+      const { barId } = requireBartender(res);
       const status = requireText(req.body, "status");
 
       if (!isOrderStatus(status)) throw HttpError.badRequest("Invalid status");
@@ -276,14 +281,15 @@ export default function createOrderRoutes(db: Db): Router {
     "/:orderId",
     route((req, res) => {
       const orderId = idParam(req, "orderId");
-      const barId = requireId(req.body, "barId");
-      const customerName = optionalText(req.body, "customerName");
+      const session = requireSession(res);
+      const { barId } = session;
 
       const order = findOrder(db, orderId, barId);
 
-      // A guest may cancel their own order, and only before it is handed over.
-      if (customerName) {
-        if (order.customer_name !== customerName) {
+      // The bartender may cancel anything in their bar. A guest may cancel only
+      // their own order, and only before it is handed over.
+      if (session.role === "guest") {
+        if (order.customer_name !== session.name) {
           throw new HttpError(403, "You can only cancel your own orders");
         }
         if (order.status === "processed") {

--- a/backend/tests/auth-enforcement.test.ts
+++ b/backend/tests/auth-enforcement.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
+import type { Db } from "../src/db/queries.js";
+
+afterAll(cleanUpTempDirs);
+
+// These are the holes the change was for: an open API where a request with no
+// credentials could do anything, and where a guest was whoever they said they
+// were. Each test here should fail against the code from before the lock-down.
+describe("locking down changes", () => {
+  let app: Express;
+  let db: Db;
+  let barId: number;
+  let drinkId: number;
+
+  beforeEach(() => {
+    ({ app, db } = makeTestApp());
+    ({ barId, drinkId } = seedBar(db));
+  });
+
+  const asBartender = (id = barId) =>
+    sessionCookie({ barId: id, role: "bartender" });
+  const asGuest = (name = "Mads", id = barId) =>
+    sessionCookie({ barId: id, role: "guest", name });
+
+  const placeOrder = (name = "Mads") =>
+    request(app)
+      .post("/api/orders")
+      .set("Cookie", asGuest(name))
+      .send({ drinkId, drinkTitle: "Negroni" });
+
+  describe("with no cookie at all", () => {
+    it("won't change a bar", async () => {
+      const res = await request(app)
+        .put(`/api/bars/${barId}`)
+        .send({ name: "Hijacked" });
+      expect(res.status).toBe(401);
+    });
+
+    it("won't add a drink", async () => {
+      const res = await request(app)
+        .post("/api/drinks")
+        .send({ title: "Free Pour", recipe: "gin" });
+      expect(res.status).toBe(401);
+    });
+
+    it("won't place an order", async () => {
+      const res = await request(app)
+        .post("/api/orders")
+        .send({ drinkId, drinkTitle: "Negroni" });
+      expect(res.status).toBe(401);
+    });
+
+    it("won't watch the live feed", async () => {
+      const res = await request(app).get("/api/events");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("as the wrong kind of user", () => {
+    it("stops a guest changing the bar", async () => {
+      const res = await request(app)
+        .put(`/api/bars/${barId}`)
+        .set("Cookie", asGuest())
+        .send({ name: "Guest Was Here" });
+      expect(res.status).toBe(403);
+    });
+
+    it("stops a guest moving an order along", async () => {
+      const placed = await placeOrder();
+      const res = await request(app)
+        .patch(`/api/orders/${placed.body.id}/status`)
+        .set("Cookie", asGuest())
+        .send({ status: "accepted" });
+      expect(res.status).toBe(403);
+    });
+
+    it("stops a bartender favouriting a drink", async () => {
+      const res = await request(app)
+        .post(`/api/drinks/bar/${barId}/favourites`)
+        .set("Cookie", asBartender())
+        .send({ drinkId });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("acting on another bar", () => {
+    it("stops a bartender changing a bar that isn't theirs", async () => {
+      const other = seedBar(db, { name: "Someone Else's Bar" });
+      const res = await request(app)
+        .put(`/api/bars/${other.barId}`)
+        .set("Cookie", asBartender(barId))
+        .send({ name: "Not Yours" });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("the name comes from the cookie, not the request", () => {
+    it("places the order as the signed-in guest, ignoring a forged name", async () => {
+      const res = await request(app)
+        .post("/api/orders")
+        .set("Cookie", asGuest("Mads"))
+        .send({ drinkId, drinkTitle: "Negroni", customerName: "Astrid" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.customer_name).toBe("Mads");
+    });
+
+    it("won't let a guest cancel someone else's order", async () => {
+      const placed = await placeOrder("Mads");
+      const res = await request(app)
+        .delete(`/api/orders/${placed.body.id}`)
+        .set("Cookie", asGuest("Astrid"));
+      expect(res.status).toBe(403);
+    });
+
+    it("still lets the bartender cancel any order", async () => {
+      const placed = await placeOrder("Mads");
+      const res = await request(app)
+        .delete(`/api/orders/${placed.body.id}`)
+        .set("Cookie", asBartender());
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import type { Express } from "express";
 import request from "supertest";
 
-import { makeTestApp, cleanUpTempDirs } from "./helpers.js";
+import { makeTestApp, cleanUpTempDirs, sessionCookie } from "./helpers.js";
 
 afterAll(cleanUpTempDirs);
 
@@ -27,6 +27,7 @@ describe("signing in", () => {
 
     await request(app)
       .put(`/api/bars/${barId}`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
       .send({ skipApproval: true })
       .expect(200);
   });

--- a/backend/tests/bar-settings.test.ts
+++ b/backend/tests/bar-settings.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 
-import { makeTestApp, cleanUpTempDirs, seedBar } from "./helpers.js";
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
 import type { Express } from "express";
 import type { Db } from "../src/db/queries.js";
 
@@ -19,13 +24,19 @@ describe("what a host can set on a bar", () => {
     app.locals.realtime = { broadcast: () => {} };
   });
 
+  const asBartender = (id = barId) =>
+    sessionCookie({ barId: id, role: "bartender" });
+  const asGuest = (name: string, id = barId) =>
+    sessionCookie({ barId: id, role: "guest", name });
+
   const setBar = (body: Record<string, unknown>) =>
-    request(app).put(`/api/bars/${barId}`).send(body);
+    request(app).put(`/api/bars/${barId}`).set("Cookie", asBartender()).send(body);
 
   const order = (customerName = "Mads") =>
     request(app)
       .post("/api/orders")
-      .send({ barId, customerName, drinkId, drinkTitle: "Negroni" });
+      .set("Cookie", asGuest(customerName))
+      .send({ drinkId, drinkTitle: "Negroni" });
 
   describe("last orders", () => {
     it("stops taking new ones, and says so plainly", async () => {
@@ -46,7 +57,8 @@ describe("what a host can set on a bar", () => {
 
       const served = await request(app)
         .patch(`/api/orders/${placed.body.id}/status`)
-        .send({ barId, status: "accepted" });
+        .set("Cookie", asBartender())
+        .send({ status: "accepted" });
 
       expect(served.status).toBe(200);
     });
@@ -128,15 +140,16 @@ describe("what a host can set on a bar", () => {
       ).id;
 
     const setOwnBar = (body: Record<string, unknown>) =>
-      request(app).put(`/api/bars/${ownBarId}`).send(body);
+      request(app)
+        .put(`/api/bars/${ownBarId}`)
+        .set("Cookie", asBartender(ownBarId))
+        .send(body);
 
     const orderAtOwnBar = () =>
-      request(app).post("/api/orders").send({
-        barId: ownBarId,
-        customerName: "Mads",
-        drinkId: ownDrinkId(),
-        drinkTitle: "Negroni",
-      });
+      request(app)
+        .post("/api/orders")
+        .set("Cookie", asGuest("Mads", ownBarId))
+        .send({ drinkId: ownDrinkId(), drinkTitle: "Negroni" });
 
     const signInAsBartender = () =>
       request(app)
@@ -223,7 +236,9 @@ describe("what a host can set on a bar", () => {
       const before = await request(app).get(`/api/bars/${barId}/qrcode`);
       const oldToken = tokenOf(before.body.url);
 
-      await request(app).post(`/api/bars/${barId}/rotate-guest-link`);
+      await request(app)
+        .post(`/api/bars/${barId}/rotate-guest-link`)
+        .set("Cookie", asBartender());
 
       const after = await request(app).get(`/api/bars/${barId}/qrcode`);
       expect(tokenOf(after.body.url)).not.toBe(oldToken);
@@ -241,7 +256,9 @@ describe("what a host can set on a bar", () => {
 
     // It is the one thing here that would let a stranger in.
     it("never sends the token out with a bar", async () => {
-      await request(app).post(`/api/bars/${barId}/rotate-guest-link`);
+      await request(app)
+        .post(`/api/bars/${barId}/rotate-guest-link`)
+        .set("Cookie", asBartender());
 
       const one = await request(app).get(`/api/bars/${barId}`);
       const list = await request(app).get("/api/bars");

--- a/backend/tests/orders.test.ts
+++ b/backend/tests/orders.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 
-import { makeTestApp, cleanUpTempDirs, seedBar } from "./helpers.js";
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
 import type { Express } from "express";
 import type { Db } from "../src/db/queries.js";
 
@@ -27,16 +32,25 @@ describe("orders", () => {
     sent = watchUpdates(app);
   });
 
-  const placeOrder = (overrides = {}) =>
-    request(app)
+  const asBartender = () => sessionCookie({ barId, role: "bartender" });
+  const asGuest = (name: string) =>
+    sessionCookie({ barId, role: "guest", name });
+
+  // The name on the order now comes from the guest's cookie, not the body, so
+  // it's set through the cookie here rather than passed in.
+  const placeOrder = (
+    overrides: {
+      customerName?: string;
+      drinkId?: number;
+      drinkTitle?: string | undefined;
+    } = {}
+  ) => {
+    const { customerName = "Mads", ...body } = overrides;
+    return request(app)
       .post("/api/orders")
-      .send({
-        barId,
-        customerName: "Mads",
-        drinkId,
-        drinkTitle: "Negroni",
-        ...overrides,
-      });
+      .set("Cookie", asGuest(customerName))
+      .send({ drinkId, drinkTitle: "Negroni", ...body });
+  };
 
   it("places an order and tells everyone", async () => {
     const res = await placeOrder();
@@ -51,7 +65,7 @@ describe("orders", () => {
   });
 
   it("refuses an order with pieces missing", async () => {
-    const res = await placeOrder({ customerName: undefined });
+    const res = await placeOrder({ drinkTitle: undefined });
 
     expect(res.status).toBe(400);
     expect(sent).not.toHaveBeenCalled();
@@ -70,7 +84,8 @@ describe("orders", () => {
 
     const res = await request(app)
       .patch(`/api/orders/${order.id}/status`)
-      .send({ barId, status: "accepted" });
+      .set("Cookie", asBartender())
+      .send({ status: "accepted" });
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("accepted");
@@ -85,7 +100,8 @@ describe("orders", () => {
 
     const res = await request(app)
       .patch(`/api/orders/${order.id}/status`)
-      .send({ barId, status: "brewing-coffee" });
+      .set("Cookie", asBartender())
+      .send({ status: "brewing-coffee" });
 
     expect(res.status).toBe(400);
   });
@@ -96,7 +112,7 @@ describe("orders", () => {
 
     const res = await request(app)
       .delete(`/api/orders/${order.id}`)
-      .send({ barId, customerName: "Mads" });
+      .set("Cookie", asGuest("Mads"));
 
     expect(res.status).toBe(200);
     expect(sent).toHaveBeenCalledWith(
@@ -134,7 +150,8 @@ describe("orders", () => {
     for (const status of statuses) {
       const res = await request(app)
         .patch(`/api/orders/${orderId}/status`)
-        .send({ barId, status });
+        .set("Cookie", asBartender())
+        .send({ status });
       expect(res.status).toBe(200);
     }
   };
@@ -155,7 +172,8 @@ describe("orders", () => {
 
     const res = await request(app)
       .patch(`/api/orders/${order.id}/status`)
-      .send({ barId, status: "processed" });
+      .set("Cookie", asBartender())
+      .send({ status: "processed" });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/cannot change status/i);
@@ -167,7 +185,8 @@ describe("orders", () => {
 
     const res = await request(app)
       .patch(`/api/orders/${order.id}/status`)
-      .send({ barId, status: "accepted" });
+      .set("Cookie", asBartender())
+      .send({ status: "accepted" });
 
     expect(res.status).toBe(400);
   });

--- a/backend/tests/qr-and-uploads.test.ts
+++ b/backend/tests/qr-and-uploads.test.ts
@@ -12,7 +12,11 @@ import {
   makeTempDir,
   cleanUpTempDirs,
   seedBar,
+  sessionCookie,
 } from "./helpers.js";
+
+/** A bartender cookie; the bar id only matters for drink routes, not uploads. */
+const asBartender = (barId = 1) => sessionCookie({ barId, role: "bartender" });
 
 // Smallest valid PNG, so the type check has something real to look at.
 const PNG = Buffer.from(
@@ -88,6 +92,7 @@ describe("photo uploads", () => {
   it("accepts a photo and serves it back", async () => {
     const upload = await request(app)
       .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
       .attach("image", PNG, { filename: "negroni.png", contentType: "image/png" });
 
     expect(upload.status).toBe(200);
@@ -122,7 +127,9 @@ describe("photo uploads", () => {
   });
 
   it("complains when nothing was sent", async () => {
-    const res = await request(app).post("/api/drinks/upload-image");
+    const res = await request(app)
+      .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender());
 
     expect(res.status).toBe(400);
   });
@@ -132,14 +139,13 @@ describe("photo uploads", () => {
 
     const upload = await request(app)
       .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender(barId))
       .attach("image", PNG, { filename: "doomed.png", contentType: "image/png" });
 
-    const created = await request(app).post("/api/drinks").send({
-      barId,
-      title: "Doomed",
-      recipe: "gin",
-      imageUrl: upload.body.imageUrl,
-    });
+    const created = await request(app)
+      .post("/api/drinks")
+      .set("Cookie", asBartender(barId))
+      .send({ title: "Doomed", recipe: "gin", imageUrl: upload.body.imageUrl });
     expect(created.status).toBe(201);
 
     const filePath = path.join(uploadsDir, upload.body.filename);
@@ -147,7 +153,7 @@ describe("photo uploads", () => {
 
     const deleted = await request(app)
       .delete(`/api/drinks/${created.body.id}`)
-      .send({ barId });
+      .set("Cookie", asBartender(barId));
 
     expect(deleted.status).toBe(200);
     expect(fs.existsSync(filePath)).toBe(false);
@@ -158,14 +164,14 @@ describe("photo uploads", () => {
     const outside = path.join(uploadsDir, "..", "keep-me.txt");
     fs.writeFileSync(outside, "should survive");
 
-    const created = await request(app).post("/api/drinks").send({
-      barId,
-      title: "Sneaky",
-      recipe: "gin",
-      imageUrl: "/uploads/../keep-me.txt",
-    });
+    const created = await request(app)
+      .post("/api/drinks")
+      .set("Cookie", asBartender(barId))
+      .send({ title: "Sneaky", recipe: "gin", imageUrl: "/uploads/../keep-me.txt" });
 
-    await request(app).delete(`/api/drinks/${created.body.id}`).send({ barId });
+    await request(app)
+      .delete(`/api/drinks/${created.body.id}`)
+      .set("Cookie", asBartender(barId));
 
     expect(fs.existsSync(outside)).toBe(true);
     fs.rmSync(outside, { force: true });

--- a/backend/tests/realtime.test.ts
+++ b/backend/tests/realtime.test.ts
@@ -7,18 +7,29 @@ import type { Request, Response } from "express";
 import type { LiveUpdate, Order } from "../../shared/types.js";
 
 import { createRealtime } from "../src/realtime.js";
-import { makeTestApp, cleanUpTempDirs, seedBar } from "./helpers.js";
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
 
 afterAll(cleanUpTempDirs);
 
-/** Stands in for a browser holding the connection open. */
-function fakeListener(barId: number) {
-  const req = Object.assign(new EventEmitter(), {
-    query: { barId: String(barId) } as Record<string, string>,
-  });
+/**
+ * Stands in for a browser holding the connection open. The bar it watches now
+ * comes from the session on res.locals, the way attachSession would leave it.
+ * Pass null to stand in for someone with no session.
+ */
+function fakeListener(barId: number | null) {
+  const req = new EventEmitter();
 
   const written: string[] = [];
   const res = {
+    locals:
+      barId === null
+        ? ({} as Record<string, unknown>)
+        : { session: { barId, role: "bartender" as const } },
     writeHead: vi.fn(),
     write: (chunk: string) => written.push(chunk),
     end: vi.fn(),
@@ -128,14 +139,13 @@ describe("live updates", () => {
     expect(realtime.listenerCount).toBe(0);
   });
 
-  it("turns away a connection that names no bar", () => {
+  it("turns away a connection with no session", () => {
     const realtime = createRealtime();
-    const listener = fakeListener(1);
-    (listener.req as unknown as { query: object }).query = {};
+    const listener = fakeListener(null);
 
     realtime.subscribe(listener.req, listener.res);
 
-    expect(listener.res.status).toHaveBeenCalledWith(400);
+    expect(listener.res.status).toHaveBeenCalledWith(401);
     expect(realtime.listenerCount).toBe(0);
   });
 
@@ -162,7 +172,12 @@ describe("the updates address", () => {
       firstChunk: string;
     }>((resolve, reject) => {
       const req = get(
-        { host: "127.0.0.1", port, path: "/api/events?barId=1" },
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/api/events",
+          headers: { Cookie: sessionCookie({ barId: 1, role: "bartender" }) },
+        },
         (res) => {
           res.once("data", (chunk) => {
             resolve({ headers: res.headers, firstChunk: chunk.toString() });
@@ -181,12 +196,12 @@ describe("the updates address", () => {
     server.close();
   });
 
-  it("turns away a connection that names no bar", async () => {
+  it("turns away a connection with no session", async () => {
     const { app } = makeTestApp();
 
     const res = await request(app).get("/api/events");
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(401);
   });
 });
 
@@ -200,7 +215,8 @@ describe("orders reach the people watching", () => {
 
     await request(app)
       .post("/api/orders")
-      .send({ barId, customerName: "Mads", drinkId, drinkTitle: "Negroni" });
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Mads" }))
+      .send({ drinkId, drinkTitle: "Negroni" });
 
     expect(listener.messages()).toEqual([
       expect.objectContaining({ type: "new_order" }),

--- a/backend/tests/uploads.test.ts
+++ b/backend/tests/uploads.test.ts
@@ -6,7 +6,12 @@ import fs from "fs";
 import path from "path";
 
 import { deletePhotoIfUnused, sweepUnusedPhotos } from "../src/uploads.js";
-import { makeTestApp, cleanUpTempDirs, seedBar } from "./helpers.js";
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
 
 const PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
@@ -28,15 +33,21 @@ describe("tidying up photos", () => {
 
   const photoOnDisk = (name: string) => fs.existsSync(path.join(uploadsDir, name));
 
+  const asBartender = () => sessionCookie({ barId, role: "bartender" });
+
   const uploadPhoto = async () => {
     const res = await request(app)
       .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
       .attach("image", PNG, { filename: "drink.png", contentType: "image/png" });
     return res.body;
   };
 
   const createDrink = (imageUrl: string, title = "Negroni") =>
-    request(app).post("/api/drinks").send({ barId, title, recipe: "gin", imageUrl });
+    request(app)
+      .post("/api/drinks")
+      .set("Cookie", asBartender())
+      .send({ title, recipe: "gin", imageUrl });
 
   it("removes the old photo when a drink gets a new one", async () => {
     const first = await uploadPhoto();
@@ -45,7 +56,8 @@ describe("tidying up photos", () => {
 
     await request(app)
       .put(`/api/drinks/${drink.body.id}`)
-      .send({ barId, imageUrl: second.imageUrl });
+      .set("Cookie", asBartender())
+      .send({ imageUrl: second.imageUrl });
 
     expect(photoOnDisk(first.filename)).toBe(false);
     expect(photoOnDisk(second.filename)).toBe(true);
@@ -57,7 +69,8 @@ describe("tidying up photos", () => {
 
     await request(app)
       .put(`/api/drinks/${drink.body.id}`)
-      .send({ barId, title: "Renamed", imageUrl: photo.imageUrl });
+      .set("Cookie", asBartender())
+      .send({ title: "Renamed", imageUrl: photo.imageUrl });
 
     expect(photoOnDisk(photo.filename)).toBe(true);
   });
@@ -67,7 +80,9 @@ describe("tidying up photos", () => {
     const one = await createDrink(photo.imageUrl, "First");
     await createDrink(photo.imageUrl, "Second");
 
-    await request(app).delete(`/api/drinks/${one.body.id}`).send({ barId });
+    await request(app)
+      .delete(`/api/drinks/${one.body.id}`)
+      .set("Cookie", asBartender());
 
     expect(photoOnDisk(photo.filename)).toBe(true);
   });
@@ -77,8 +92,12 @@ describe("tidying up photos", () => {
     const one = await createDrink(photo.imageUrl, "First");
     const two = await createDrink(photo.imageUrl, "Second");
 
-    await request(app).delete(`/api/drinks/${one.body.id}`).send({ barId });
-    await request(app).delete(`/api/drinks/${two.body.id}`).send({ barId });
+    await request(app)
+      .delete(`/api/drinks/${one.body.id}`)
+      .set("Cookie", asBartender());
+    await request(app)
+      .delete(`/api/drinks/${two.body.id}`)
+      .set("Cookie", asBartender());
 
     expect(photoOnDisk(photo.filename)).toBe(false);
   });


### PR DESCRIPTION
Part 2 of 3 towards real authentication (#53), building on the session cookie
from #57 (now in `staging`). Part 1 issued the cookie but enforced nothing;
this makes every mutating route and the live feed actually check it.

## Why

With #57 alone, a request with no cookie could still change anything — the
groundwork was laid but no gate was closed. This adds the gates, and takes the
acting bar from the cookie instead of the request body, closing the
"pass someone else's barId" hole.

## What changes

- **Role helpers** in `auth/middleware.ts`: `requireBartender` /
  `requireGuest` / `requireSession` resolve the cookie to a bar (and, for a
  guest, their name) or throw 401/403. Routes call them and let the existing
  `route()` wrapper turn a throw into the reply — no try/catch.
- **The 21 mutating routes take their bar from the session:**
  - *Bartender-only*: bar edit/delete/rotate-link (and only their **own** bar),
    all drink management, all categories, and moving an order along.
  - *Guest*: placing an order and favouriting a drink, both under the name on
    the cookie — so nobody orders, cancels, or favourites as someone else.
  - *Either*: cancelling an order — a guest only their own, the bartender any
    order in their bar. This replaces the old trust-the-body `customerName`
    check.
- **The live feed** (`/api/events`) takes the bar from the cookie too, so a
  browser only ever watches the bar it signed in to, and a request with no
  session is turned away.
- Sign-in, bar creation, and the guest QR exchange stay open (they *issue* the
  cookie).

## A refinement to the plan

The two `favourites` endpoints in `drinks.ts` are **guest** actions (keyed by
customer name), not bartender ones as the original plan lumped them — so they
require a guest session, with the name taken from the cookie. That's the only
deviation from the written plan, and it's the more correct split.

## Scope

Reads stay open for now (bar lists, menus, order history, analytics, QR code);
locking those down is a later pass, once the frontend holds a session. This PR
is backend-only — the frontend still signs in via `localStorage` until part 3
moves it onto `GET /api/auth/me`.

## Tests

Every mutation/SSE test now carries a cookie via the `sessionCookie()` helper.
A new `auth-enforcement.test.ts` covers the closed holes and is written to fail
against the pre-enforcement code: no-cookie changes are refused (401), a guest
can't do a bartender's job (403), a bartender can't touch another bar (403),
a guest can't cancel someone else's order (403), and the name on an order comes
from the cookie even when the body says otherwise. 115 backend tests pass; lint,
typecheck and the production build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_