### PR TITLE
Trust the sign-in cookie on the pages, not localStorage (#53, part 3 of 3)

### DIFF
--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useState, ReactNode } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  ReactNode,
+} from "react";
 
 import { AppContext, type AppContextType } from "../hooks/useApp";
 import { apiCall } from "../utils/api";
@@ -11,6 +17,7 @@ import type {
   Drink,
   Language,
   Order,
+  SignedIn,
   UserType,
 } from "../types";
 
@@ -81,49 +88,42 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setLanguageChosen,
   ]);
 
-  // Session validation effect
+  // Reconcile the remembered sign-in with the real one. The cookie is the
+  // session now; the stored bar and name are only for showing something while
+  // we ask. If the server says we are not signed in, forget it here too — so a
+  // stale localStorage without a live cookie can't look signed in.
+  const reconciled = useRef(false);
   useEffect(() => {
-    const validateSession = () => {
-      // Only validate sessions that should be fully authenticated
-      // This means checking routes that require authentication, not just the presence of userType/currentBar
-      const currentPath = window.location.pathname;
-      const isOnProtectedRoute =
-        currentPath.startsWith("/customer") ||
-        currentPath.startsWith("/bartender");
+    if (reconciled.current) return;
+    reconciled.current = true;
+    // Nothing to reconcile for someone who was never signed in.
+    if (!userType) return;
 
-      // Only validate if user is on a protected route
-      if (isOnProtectedRoute) {
-        // If on customer route but missing authentication requirements
-        if (currentPath.startsWith("/customer")) {
-          if (
-            !userType ||
-            !currentBar ||
-            userType !== "guest" ||
-            !customerName
-          ) {
-            console.log(
-              "Invalid customer session on protected route, resetting..."
-            );
-            clearAllData();
-            return;
-          }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/auth/me", { credentials: "include" });
+        if (cancelled) return;
+        if (res.status === 401) {
+          clearAllData();
+          return;
         }
+        // A blip rather than a sign-out — keep showing what we remembered.
+        if (!res.ok) return;
 
-        // If on bartender route but missing authentication requirements
-        if (currentPath.startsWith("/bartender")) {
-          if (!userType || !currentBar || userType !== "bartender") {
-            console.log(
-              "Invalid bartender session on protected route, resetting..."
-            );
-            clearAllData();
-            return;
-          }
-        }
+        const me = (await res.json()) as SignedIn;
+        setUserType(me.userType);
+        setCurrentBar(me.bar);
+        if (me.userType === "guest") setCustomerName(me.customerName ?? "");
+      } catch {
+        // Offline or unreachable: leave the remembered state be.
       }
-    };
+    })();
 
-    validateSession();
-  }, [userType, currentBar, customerName, clearAllData]);
+    return () => {
+      cancelled = true;
+    };
+  }, [userType, clearAllData, setUserType, setCurrentBar, setCustomerName]);
 
   const value: AppContextType = {
     // App state

--- a/frontend/src/context/LiveUpdatesContext.tsx
+++ b/frontend/src/context/LiveUpdatesContext.tsx
@@ -52,7 +52,10 @@ export const LiveUpdatesProvider: React.FC<{ children: ReactNode }> = ({
       return;
     }
 
-    const source = new EventSource(`/api/events?barId=${barId}`);
+    // The server reads the bar from the sign-in cookie, so no id in the address.
+    // withCredentials sends that cookie in development, where the pages come
+    // from a different origin.
+    const source = new EventSource("/api/events", { withCredentials: true });
 
     const startComplaining = () => {
       if (complainTimer.current) return;

--- a/frontend/src/hooks/useSessionManager.ts
+++ b/frontend/src/hooks/useSessionManager.ts
@@ -23,7 +23,7 @@ export function rememberMe(remember: boolean): void {
 const isRemembered = () => localStorage.getItem(REMEMBER_KEY) === "true";
 
 export const useSessionManager = () => {
-  const { setUserType, setCurrentBar, setCustomerName, setLoginForm } =
+  const { setUserType, setCurrentBar, setCustomerName, setLoginForm, apiCall } =
     useApp();
 
   const navigate = useNavigate();
@@ -42,6 +42,9 @@ export const useSessionManager = () => {
   }, []);
 
   const clearSession = useCallback(() => {
+    // Drop the cookie on the server too, or the next visit would just sign
+    // back in from it. Fire and forget — signing out here happens regardless.
+    void apiCall("/auth/logout", { method: "POST" }).catch(() => {});
     navigate("/");
     setUserType(null);
     setCurrentBar(null);
@@ -50,7 +53,14 @@ export const useSessionManager = () => {
     localStorage.removeItem(ACTIVITY_KEY);
     // Signing out is the guest saying it is not them, so forget them too.
     localStorage.removeItem(REMEMBER_KEY);
-  }, [navigate, setUserType, setCurrentBar, setCustomerName, setLoginForm]);
+  }, [
+    apiCall,
+    navigate,
+    setUserType,
+    setCurrentBar,
+    setCustomerName,
+    setLoginForm,
+  ]);
 
   useEffect(() => {
     const isOnLandingPage = location.pathname === "/";

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -12,11 +12,14 @@ export async function apiCall<T = unknown>(
   options: RequestInit = {}
 ): Promise<T> {
   const response = await fetch(`${API_BASE}${endpoint}`, {
+    ...options,
+    // Send the sign-in cookie along. Same-origin already would; this also
+    // covers development, where the pages come from a different address.
+    credentials: "include",
     headers: {
       "Content-Type": "application/json",
       ...options.headers,
     },
-    ...options,
   });
 
   if (!response.ok) {

--- a/frontend/tests/liveUpdates.test.tsx
+++ b/frontend/tests/liveUpdates.test.tsx
@@ -58,8 +58,9 @@ describe("live updates", () => {
   it("watches the bar the guest is in", async () => {
     show();
 
+    // The bar comes from the sign-in cookie now, not the address.
     await waitFor(() => expect(FakeEventSource.live).toHaveLength(1));
-    expect(FakeEventSource.live[0].url).toBe("/api/events?barId=1");
+    expect(FakeEventSource.live[0].url).toBe("/api/events");
   });
 
   it("fetches the orders again when one arrives or changes", async () => {

--- a/frontend/tests/session.test.tsx
+++ b/frontend/tests/session.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+
+import { AppProvider } from "../src/context/AppContext";
+import { useApp } from "../src/hooks/useApp";
+import { signIn, aBar } from "./helpers";
+
+/** Shows who the app thinks is signed in, after it has checked with the server. */
+const Probe: React.FC = () => {
+  const { userType, currentBar } = useApp();
+  return (
+    <span data-testid="who">
+      {userType ?? "nobody"}
+      {currentBar ? `:${currentBar.name}` : ""}
+    </span>
+  );
+};
+
+const show = () =>
+  render(
+    <AppProvider>
+      <Probe />
+    </AppProvider>
+  );
+
+/** Answers only the session check, with a chosen status and body. */
+function stubMe(status: number, body: unknown = {}) {
+  const fetchMock = vi.fn(
+    async () =>
+      ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+      }) as Response
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+// The whole point of the change: a remembered sign-in is only as good as the
+// cookie behind it. The app asks the server on load and believes the answer.
+describe("checking the sign-in on load", () => {
+  it("forgets a session the server no longer knows", async () => {
+    signIn({ as: "bartender", bar: aBar() });
+    stubMe(401);
+
+    show();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("who").textContent).toBe("nobody")
+    );
+    // And nothing is left behind to look signed in on the next load.
+    expect(localStorage.getItem("homeBarSystem_userType")).toBeNull();
+  });
+
+  it("keeps a session the server confirms, with the bar it sends back", async () => {
+    signIn({ as: "bartender", bar: aBar({ name: "Yesterday's Name" }) });
+    stubMe(200, {
+      success: true,
+      userType: "bartender",
+      bar: aBar({ name: "Today's Name" }),
+    });
+
+    show();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("who").textContent).toBe(
+        "bartender:Today's Name"
+      )
+    );
+  });
+
+  it("does not sign out on a network blip", async () => {
+    signIn({ as: "bartender", bar: aBar() });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    show();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // The check failed to reach the server, so the remembered sign-in stands.
+    expect(screen.getByTestId("who").textContent).toBe(
+      "bartender:The Spotted Cow"
+    );
+  });
+
+  it("leaves a never-signed-in visitor alone, without even asking", async () => {
+    const fetchMock = stubMe(401);
+
+    show();
+
+    expect(screen.getByTestId("who").textContent).toBe("nobody");
+    // No session to check, so no round trip to make.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The last part of #53, on top of #57 and #58 (both in `staging`). The backend
now issues a session cookie and enforces it on every change; this moves the
**pages** onto that cookie instead of trusting `localStorage`.

## Why

With the API enforced, a remembered sign-in with no live cookie would still
*look* signed in — the app decided from `localStorage` alone — but every request
would be refused. The pages need to believe the cookie, not their own memory.

## What changes

- **`apiCall` sends credentials**, so the cookie rides on every request.
  Same-origin already would; this also covers development, where the pages come
  from a different address.
- **The app checks `GET /api/auth/me` on load and believes it:**
  - `401` → forget the remembered sign-in and clear `localStorage`, so it can't
    look signed in next time.
  - a good reply → refresh the bar and name from the server.
  - a network blip → leave the remembered state alone (don't sign someone out
    over a hiccup).
  - never-signed-in → don't even make the call.

  This replaces the old check that only compared `localStorage` against the
  current route.
- **Signing out drops the cookie** (`POST /api/auth/logout`) — otherwise the
  next visit's `/me` would just sign back in from the lingering cookie.
- **The live feed** opens without a bar in the address (the server reads it from
  the cookie) and with credentials so the cookie rides along in dev.

## What needed no change

Sign-in, bar creation, and the guest QR flow already set the display state, and
the server sets the cookie on the same reply — so they're untouched. Request
bodies still carry a bar id / name, which the server now **ignores**; stripping
them is cosmetic and left for a later tidy-up.

## Tests

A new `session.test.tsx` covers the load-time check: a session the server has
forgotten is cleared (and `localStorage` with it), a confirmed one adopts the
server's bar, a network blip doesn't sign anyone out, and a fresh visitor is
left alone without a round trip. The one existing test that asserted the live
feed's URL now expects `/api/events` (no `?barId`). 94 frontend tests pass;
lint, typecheck and the production build are green.

## After this lands

The full #53 arc is done: the API is authenticated end-to-end and the UI runs
on real sessions. Remaining follow-ups already have homes — locking down read
endpoints, the operator panel and recovery command (#53's later phases), the
longer guest cookie, and per-guest passwords (#56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_