### PR TITLE
Require a session to read a bar's menu, queue and takings (#53)

### DIFF
--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -63,3 +63,27 @@ export function requireGuest(res: Response): { barId: number; name: string } {
   }
   return { barId: session.barId, name: session.name };
 }
+
+/**
+ * A bartender signed in to the bar named in the address. The address carries a
+ * bar id, so this checks the cookie is for that same bar — a valid sign-in to
+ * one bar can't read another's orders or takings.
+ */
+export function requireBartenderForBar(res: Response, barId: number): void {
+  const session = requireBartender(res);
+  if (session.barId !== barId) {
+    throw HttpError.forbidden("You can only see your own bar");
+  }
+}
+
+/**
+ * Anyone signed in to the bar named in the address — guest or bartender. For
+ * the shared reads (the menu, the order queue) that both kinds need.
+ */
+export function requireBarMember(res: Response, barId: number): Session {
+  const session = requireSession(res);
+  if (session.barId !== barId) {
+    throw HttpError.forbidden("You can only see your own bar");
+  }
+  return session;
+}

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -23,7 +23,10 @@ import {
   wasSent,
 } from "../http.js";
 import { setSessionCookie } from "../auth/session.js";
-import { requireBartender } from "../auth/middleware.js";
+import {
+  requireBartender,
+  requireBartenderForBar,
+} from "../auth/middleware.js";
 import {
   all,
   buildUpdate,
@@ -254,6 +257,7 @@ export default function createBarRoutes({
     "/:id/dashboard",
     route((req, res) => {
       const barId = idParam(req, "id");
+      requireBartenderForBar(res, barId);
       const bar = publicBar(findBar(db, barId));
 
       res.json({
@@ -346,6 +350,7 @@ export default function createBarRoutes({
     "/:id/qrcode",
     route(async (req, res) => {
       const barId = idParam(req, "id");
+      requireBartenderForBar(res, barId);
       const bar = findBar(db, barId);
 
       // Prefer a configured address, otherwise the one the request arrived on

--- a/backend/src/routes/categories.ts
+++ b/backend/src/routes/categories.ts
@@ -3,7 +3,10 @@ import express, { type Router } from "express";
 import type { Category } from "../../../shared/types.js";
 import { HttpError, idParam, requireText, route } from "../http.js";
 import { all, count, findCategory, one, run, type Db } from "../db/queries.js";
-import { requireBartender } from "../auth/middleware.js";
+import {
+  requireBartender,
+  requireBartenderForBar,
+} from "../auth/middleware.js";
 
 export default function createCategoryRoutes(db: Db): Router {
   const router = express.Router();
@@ -12,6 +15,7 @@ export default function createCategoryRoutes(db: Db): Router {
     "/bar/:barId",
     route((req, res) => {
       const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
 
       res.json(
         all<Category>(

--- a/backend/src/routes/drinks.ts
+++ b/backend/src/routes/drinks.ts
@@ -1,4 +1,4 @@
-import express, { type Router } from "express";
+import express, { type Response, type Router } from "express";
 import multer from "multer";
 import path from "path";
 import fs from "fs";
@@ -28,7 +28,12 @@ import {
   run,
   type Db,
 } from "../db/queries.js";
-import { requireBartender, requireGuest } from "../auth/middleware.js";
+import {
+  requireBarMember,
+  requireBartender,
+  requireBartenderForBar,
+  requireGuest,
+} from "../auth/middleware.js";
 import { deletePhotoIfUnused } from "../uploads.js";
 
 const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
@@ -47,6 +52,18 @@ function asGuestSees<T extends Drink>(drinks: T[]): T[] {
   return drinks.map((drink) =>
     drink.show_recipe_to_guests ? drink : { ...drink, recipe: null }
   );
+}
+
+/**
+ * A signed-in member of this bar. A guest may only ask by their own name, so
+ * one guest can't read another's list by putting a different name in the
+ * address; the bartender may look up anyone.
+ */
+function ownList(res: Response, barId: number, name: string): void {
+  const session = requireBarMember(res, barId);
+  if (session.role === "guest" && session.name !== name) {
+    throw HttpError.forbidden("You can only see your own list");
+  }
 }
 
 interface DrinkRoutesOptions {
@@ -106,11 +123,13 @@ export default function createDrinkRoutes({
   router.get(
     "/bar/:barId",
     route((req, res) => {
+      const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
       res.json(
         all<DrinkWithCategory>(
           db,
           `${WITH_CATEGORY} WHERE d.bar_id = ? ORDER BY d.created_at DESC`,
-          idParam(req, "barId")
+          barId
         )
       );
     })
@@ -119,12 +138,14 @@ export default function createDrinkRoutes({
   router.get(
     "/bar/:barId/guest",
     route((req, res) => {
+      const barId = idParam(req, "barId");
+      requireBarMember(res, barId);
       res.json(
         asGuestSees(
           all<DrinkWithCategory>(
             db,
             `${WITH_CATEGORY} WHERE d.bar_id = ? ORDER BY d.created_at DESC`,
-            idParam(req, "barId")
+            barId
           )
         )
       );
@@ -134,7 +155,9 @@ export default function createDrinkRoutes({
   router.get(
     "/bar/:barId/drink/:drinkId",
     route((req, res) => {
-      res.json(findDrink(db, idParam(req, "drinkId"), idParam(req, "barId")));
+      const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
+      res.json(findDrink(db, idParam(req, "drinkId"), barId));
     })
   );
 
@@ -271,6 +294,7 @@ export default function createDrinkRoutes({
     "/bar/:barId/analytics",
     route((req, res) => {
       const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
 
       const report = {
         popularDrinks: all<{ drink_title: string; order_count: number }>(
@@ -301,6 +325,7 @@ export default function createDrinkRoutes({
     route((req, res) => {
       const barId = idParam(req, "barId");
       const customerName = req.params.customerName ?? "";
+      ownList(res, barId, customerName);
 
       res.json(
         asGuestSees(
@@ -374,6 +399,7 @@ export default function createDrinkRoutes({
     route((req, res) => {
       const barId = idParam(req, "barId");
       const customerName = req.params.customerName ?? "";
+      ownList(res, barId, customerName);
 
       res.json(
         asGuestSees(

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -24,7 +24,9 @@ import {
   type Db,
 } from "../db/queries.js";
 import {
+  requireBarMember,
   requireBartender,
+  requireBartenderForBar,
   requireGuest,
   requireSession,
 } from "../auth/middleware.js";
@@ -57,6 +59,9 @@ export default function createOrderRoutes(db: Db): Router {
     "/bar/:barId",
     route((req, res) => {
       const barId = idParam(req, "barId");
+      // Both the bartender's queue and the guest's own view read this, so it's
+      // open to anyone signed in to this bar — but nobody else.
+      requireBarMember(res, barId);
       const { status, customerName } = req.query;
       const limit = Math.min(Number(req.query["limit"] ?? 100) || 100, 500);
 
@@ -88,12 +93,14 @@ export default function createOrderRoutes(db: Db): Router {
   router.get(
     "/bar/:barId/pending",
     route((req, res) => {
+      const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
       res.json(
         all<OrderForBartender>(
           db,
           `${WITH_RECIPE} WHERE o.bar_id = ? AND o.status IN (${OPEN})
            ORDER BY o.created_at ASC`,
-          idParam(req, "barId")
+          barId
         )
       );
     })
@@ -104,6 +111,12 @@ export default function createOrderRoutes(db: Db): Router {
     route((req, res) => {
       const barId = idParam(req, "barId");
       const customerName = decodeURIComponent(req.params.customerName ?? "");
+
+      // A guest may only look up their own waiting order; the bartender, anyone's.
+      const session = requireBarMember(res, barId);
+      if (session.role === "guest" && session.name !== customerName) {
+        throw HttpError.forbidden("You can only see your own orders");
+      }
 
       res.json(
         one<Order>(
@@ -210,6 +223,7 @@ export default function createOrderRoutes(db: Db): Router {
     "/bar/:barId/analytics",
     route((req, res) => {
       const barId = idParam(req, "barId");
+      requireBartenderForBar(res, barId);
       const days = periodInDays(req.query["days"]);
       // A window expressed for SQLite, built from a checked number.
       const since = `-${days} days`;

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -61,7 +61,7 @@ export default function createOrderRoutes(db: Db): Router {
       const barId = idParam(req, "barId");
       // Both the bartender's queue and the guest's own view read this, so it's
       // open to anyone signed in to this bar — but nobody else.
-      requireBarMember(res, barId);
+      const session = requireBarMember(res, barId);
       const { status, customerName } = req.query;
       const limit = Math.min(Number(req.query["limit"] ?? 100) || 100, 500);
 
@@ -73,9 +73,19 @@ export default function createOrderRoutes(db: Db): Router {
         params.push(status);
       }
 
-      if (typeof customerName === "string") {
+      // The bartender sees the whole room and may narrow by name. A guest only
+      // ever sees their own orders — the name comes from their cookie, so they
+      // can't widen it to anyone else's by asking.
+      const onlyName =
+        session.role === "guest"
+          ? (session.name ?? "")
+          : typeof customerName === "string"
+            ? customerName
+            : null;
+
+      if (onlyName !== null) {
         filters.push("o.customer_name = ?");
-        params.push(customerName);
+        params.push(onlyName);
       }
 
       res.json(

--- a/backend/tests/bar-settings.test.ts
+++ b/backend/tests/bar-settings.test.ts
@@ -223,7 +223,9 @@ describe("what a host can set on a bar", () => {
     const tokenOf = (url: string) => new URL(url).searchParams.get("token");
 
     it("keeps working on a code that was printed before it could be rotated", async () => {
-      const qr = await request(app).get(`/api/bars/${barId}/qrcode`);
+      const qr = await request(app)
+        .get(`/api/bars/${barId}/qrcode`)
+        .set("Cookie", asBartender());
 
       const login = await request(app)
         .post(`/api/bars/${barId}/guest-token-login`)
@@ -233,14 +235,18 @@ describe("what a host can set on a bar", () => {
     });
 
     it("turns the old link off once a new one is made", async () => {
-      const before = await request(app).get(`/api/bars/${barId}/qrcode`);
+      const before = await request(app)
+        .get(`/api/bars/${barId}/qrcode`)
+        .set("Cookie", asBartender());
       const oldToken = tokenOf(before.body.url);
 
       await request(app)
         .post(`/api/bars/${barId}/rotate-guest-link`)
         .set("Cookie", asBartender());
 
-      const after = await request(app).get(`/api/bars/${barId}/qrcode`);
+      const after = await request(app)
+        .get(`/api/bars/${barId}/qrcode`)
+        .set("Cookie", asBartender());
       expect(tokenOf(after.body.url)).not.toBe(oldToken);
 
       const withOld = await request(app)

--- a/backend/tests/orders.test.ts
+++ b/backend/tests/orders.test.ts
@@ -120,7 +120,9 @@ describe("orders", () => {
       expect.objectContaining({ type: "order_deleted" })
     );
 
-    const remaining = await request(app).get(`/api/orders/bar/${barId}`);
+    const remaining = await request(app)
+      .get(`/api/orders/bar/${barId}`)
+      .set("Cookie", asBartender());
     expect(remaining.body).toHaveLength(0);
   });
 
@@ -128,18 +130,18 @@ describe("orders", () => {
     await placeOrder();
     await placeOrder({ customerName: "Someone Else" });
 
-    const res = await request(app).get(
-      `/api/orders/bar/${barId}/customer/${encodeURIComponent("Mads")}`
-    );
+    const res = await request(app)
+      .get(`/api/orders/bar/${barId}/customer/${encodeURIComponent("Mads")}`)
+      .set("Cookie", asGuest("Mads"));
 
     expect(res.status).toBe(200);
     expect(res.body.customer_name).toBe("Mads");
   });
 
   it("gives nothing back when a guest has no order waiting", async () => {
-    const res = await request(app).get(
-      `/api/orders/bar/${barId}/customer/${encodeURIComponent("Nobody")}`
-    );
+    const res = await request(app)
+      .get(`/api/orders/bar/${barId}/customer/${encodeURIComponent("Nobody")}`)
+      .set("Cookie", asGuest("Nobody"));
 
     expect(res.status).toBe(200);
     expect(res.body).toBeNull();
@@ -195,9 +197,9 @@ describe("orders", () => {
     const { body: order } = await placeOrder();
     await advanceTo(order.id, "accepted", "ready", "processed");
 
-    const res = await request(app).get(
-      `/api/orders/bar/${barId}/customer/${encodeURIComponent("Mads")}`
-    );
+    const res = await request(app)
+      .get(`/api/orders/bar/${barId}/customer/${encodeURIComponent("Mads")}`)
+      .set("Cookie", asGuest("Mads"));
 
     expect(res.body).toBeNull();
   });
@@ -206,7 +208,11 @@ describe("orders", () => {
     const other = seedBar(db, { name: "Other Bar" });
     await placeOrder();
 
-    const res = await request(app).get(`/api/orders/bar/${other.barId}`);
+    // Read the other bar as its own bartender: the order landed in this bar,
+    // not that one.
+    const res = await request(app)
+      .get(`/api/orders/bar/${other.barId}`)
+      .set("Cookie", sessionCookie({ barId: other.barId, role: "bartender" }));
 
     expect(res.body).toHaveLength(0);
   });

--- a/backend/tests/qr-and-uploads.test.ts
+++ b/backend/tests/qr-and-uploads.test.ts
@@ -37,7 +37,9 @@ describe("qr code addresses", () => {
   });
 
   it("uses the address the request came in on", async () => {
-    const res = await request(app).get(`/api/bars/${barId}/qrcode`);
+    const res = await request(app)
+      .get(`/api/bars/${barId}/qrcode`)
+      .set("Cookie", asBartender(barId));
 
     expect(res.status).toBe(200);
     expect(res.body.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/bar\/\d+\?token=/);
@@ -46,6 +48,7 @@ describe("qr code addresses", () => {
   it("follows a reverse proxy that reports the real address", async () => {
     const res = await request(app)
       .get(`/api/bars/${barId}/qrcode`)
+      .set("Cookie", asBartender(barId))
       .set("X-Forwarded-Proto", "https")
       .set("X-Forwarded-For", "10.0.0.5")
       .set("Host", "bar.example.com");
@@ -69,6 +72,7 @@ describe("qr code addresses", () => {
 
     const res = await request(configured)
       .get(`/api/bars/${seeded.barId}/qrcode`)
+      .set("Cookie", asBartender(seeded.barId))
       .set("X-Forwarded-Proto", "http")
       .set("Host", "somewhere-else.example.com");
 
@@ -76,7 +80,9 @@ describe("qr code addresses", () => {
   });
 
   it("returns a scannable image", async () => {
-    const res = await request(app).get(`/api/bars/${barId}/qrcode`);
+    const res = await request(app)
+      .get(`/api/bars/${barId}/qrcode`)
+      .set("Cookie", asBartender(barId));
 
     expect(res.body.qrCode).toMatch(/^data:image\/png;base64,/);
   });

--- a/backend/tests/read-enforcement.test.ts
+++ b/backend/tests/read-enforcement.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  sessionCookie,
+} from "./helpers.js";
+import type { Db } from "../src/db/queries.js";
+
+afterAll(cleanUpTempDirs);
+
+// Reading used to be wide open: with no cookie at all you could pull a bar's
+// whole menu with recipes, its order queue with everyone's names, and its
+// takings. Each test here should fail against the code from before the reads
+// were locked down.
+describe("locking down what can be read", () => {
+  let app: Express;
+  let db: Db;
+  let barId: number;
+
+  beforeEach(() => {
+    ({ app, db } = makeTestApp());
+    ({ barId } = seedBar(db));
+  });
+
+  const asBartender = (id = barId) =>
+    sessionCookie({ barId: id, role: "bartender" });
+  const asGuest = (name = "Mads", id = barId) =>
+    sessionCookie({ barId: id, role: "guest", name });
+
+  // The bartender's own views: the full menu with recipes, the queue, the
+  // takings, the printable code. None of these should answer a stranger.
+  const bartenderReads = () => [
+    `/api/bars/${barId}/dashboard`,
+    `/api/bars/${barId}/qrcode`,
+    `/api/drinks/bar/${barId}`,
+    `/api/drinks/bar/${barId}/analytics`,
+    `/api/categories/bar/${barId}`,
+    `/api/orders/bar/${barId}/pending`,
+    `/api/orders/bar/${barId}/analytics`,
+  ];
+
+  describe("with no cookie at all", () => {
+    it("turns away every bartender-only read", async () => {
+      for (const path of bartenderReads()) {
+        const res = await request(app).get(path);
+        expect(res.status, path).toBe(401);
+      }
+    });
+
+    it("won't hand out the menu", async () => {
+      const res = await request(app).get(`/api/drinks/bar/${barId}/guest`);
+      expect(res.status).toBe(401);
+    });
+
+    it("won't hand out the order queue", async () => {
+      const res = await request(app).get(`/api/orders/bar/${barId}`);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // The sign-in screen and the QR welcome need these before anyone has a
+  // cookie, so they stay open on purpose.
+  describe("the bits sign-in needs stay open", () => {
+    it("lists the bars to pick from", async () => {
+      const res = await request(app).get("/api/bars");
+      expect(res.status).toBe(200);
+    });
+
+    it("shows a single bar's public details", async () => {
+      const res = await request(app).get(`/api/bars/${barId}`);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toHaveProperty("guest_token");
+    });
+  });
+
+  describe("a guest can't reach the bartender's views", () => {
+    it("is turned away from all of them", async () => {
+      for (const path of bartenderReads()) {
+        const res = await request(app).get(path).set("Cookie", asGuest());
+        expect(res.status, path).toBe(403);
+      }
+    });
+
+    it("but can read the menu", async () => {
+      const res = await request(app)
+        .get(`/api/drinks/bar/${barId}/guest`)
+        .set("Cookie", asGuest());
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("a sign-in for one bar can't read another", () => {
+    it("stops a bartender reading a bar that isn't theirs", async () => {
+      const other = seedBar(db, { name: "Someone Else's Bar" });
+      const res = await request(app)
+        .get(`/api/orders/bar/${other.barId}/pending`)
+        .set("Cookie", asBartender(barId));
+      expect(res.status).toBe(403);
+    });
+
+    it("stops a guest reading a bar they didn't join", async () => {
+      const other = seedBar(db, { name: "Someone Else's Bar" });
+      const res = await request(app)
+        .get(`/api/drinks/bar/${other.barId}/guest`)
+        .set("Cookie", asGuest("Mads", barId));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("a guest can only look up their own name", () => {
+    it("reads their own favourites", async () => {
+      const res = await request(app)
+        .get(`/api/drinks/bar/${barId}/favourites/Mads`)
+        .set("Cookie", asGuest("Mads"));
+      expect(res.status).toBe(200);
+    });
+
+    it("not another guest's favourites", async () => {
+      const res = await request(app)
+        .get(`/api/drinks/bar/${barId}/favourites/Astrid`)
+        .set("Cookie", asGuest("Mads"));
+      expect(res.status).toBe(403);
+    });
+
+    it("not another guest's waiting order", async () => {
+      const res = await request(app)
+        .get(`/api/orders/bar/${barId}/customer/Astrid`)
+        .set("Cookie", asGuest("Mads"));
+      expect(res.status).toBe(403);
+    });
+
+    // The bartender is trusted with the whole room, so any name is fine.
+    it("but the bartender may look up anyone", async () => {
+      const res = await request(app)
+        .get(`/api/orders/bar/${barId}/customer/Astrid`)
+        .set("Cookie", asBartender());
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/tests/read-enforcement.test.ts
+++ b/backend/tests/read-enforcement.test.ts
@@ -20,16 +20,25 @@ describe("locking down what can be read", () => {
   let app: Express;
   let db: Db;
   let barId: number;
+  let drinkId: number;
 
   beforeEach(() => {
     ({ app, db } = makeTestApp());
-    ({ barId } = seedBar(db));
+    ({ barId, drinkId } = seedBar(db));
+    // The order queue reads this, and it's fine to have no one listening.
+    app.locals.realtime = { broadcast: () => {} };
   });
 
   const asBartender = (id = barId) =>
     sessionCookie({ barId: id, role: "bartender" });
   const asGuest = (name = "Mads", id = barId) =>
     sessionCookie({ barId: id, role: "guest", name });
+
+  const placeOrder = (name: string) =>
+    request(app)
+      .post("/api/orders")
+      .set("Cookie", asGuest(name))
+      .send({ drinkId, drinkTitle: "Negroni" });
 
   // The bartender's own views: the full menu with recipes, the queue, the
   // takings, the printable code. None of these should answer a stranger.
@@ -139,6 +148,40 @@ describe("locking down what can be read", () => {
         .get(`/api/orders/bar/${barId}/customer/Astrid`)
         .set("Cookie", asBartender());
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("the order queue is filtered to who is reading it", () => {
+    beforeEach(async () => {
+      await placeOrder("Mads");
+      await placeOrder("Astrid");
+    });
+
+    it("gives a guest only their own orders", async () => {
+      const res = await request(app)
+        .get(`/api/orders/bar/${barId}`)
+        .set("Cookie", asGuest("Mads"));
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].customer_name).toBe("Mads");
+    });
+
+    it("won't widen to another guest by asking for their name", async () => {
+      const res = await request(app)
+        .get(`/api/orders/bar/${barId}?customerName=Astrid`)
+        .set("Cookie", asGuest("Mads"));
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].customer_name).toBe("Mads");
+    });
+
+    it("still gives the bartender the whole room", async () => {
+      const res = await request(app)
+        .get(`/api/orders/bar/${barId}`)
+        .set("Cookie", asBartender());
+
+      expect(res.body).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
Closes the last open surface from the #53 auth work: the read endpoints. Parts 1–3 required a session for every change and the live feed, but left reads open so the guest menu and the QR-join flow would keep working before the cookie exchange shipped. It has shipped, so this closes the reads too.

## What changed

Every read is now scoped to the bar in the cookie, in three tiers:

| Tier | Endpoints |
|------|-----------|
| **Public** — sign-in needs them before anyone has a cookie | `GET /bars` (the picker), `GET /bars/:id` (public bar details for the QR welcome) |
| **Bar member** — guest *or* bartender of that bar | the guest menu, the order queue |
| **Bartender only** — of that bar | full menu with recipes, a single drink, the dashboard, the printable QR code, the categories, and both analytics reports |

Two extra tightenings on top of "must be signed in":

- **A guest can only look themselves up by name.** One guest can no longer read another's favourites or waiting order by editing the name in the address.
- **The order queue is filtered to who's reading it.** The bartender sees the whole room and may narrow by name; a guest gets only their own orders, taken from the name in their cookie, and can't widen it with a `customerName` query.

## Why these tiers

- `GET /orders/bar/:barId` stays open to any bar member because both the bartender's queue screen and the guest's own view read it — but the guest now only gets their own rows off it.
- `GET /categories/bar/:barId` becomes bartender-only: the guest menu never calls it (category names arrive embedded in the drink rows), only the bartender's drink form and categories tab do.

## Frontend

No change needed. The pages already send the cookie on every request and `EventSource` runs with credentials (part 3). I checked every read call site: no guest-facing path calls a now-bartender-only endpoint, and the guest UI already filtered the orders list to the guest's own name in both places it shows it (`currentOrder` in `CustomerInterface`, `mine` in `PastOrdersPanel`) — so the tighter queue changes nothing on screen, it just stops other guests' names and recipes crossing the wire.

## Tests

`backend/tests/read-enforcement.test.ts` is new and written to fail against the pre-lockdown code: no-cookie reads → 401, a guest reaching a bartender-only read → 403, a sign-in for one bar reading another → 403, a guest reading another guest's name → 403, and the queue filtered to the reader (guest gets their own, bartender gets the room). Existing read tests (qr code, orders, bar settings) now carry the right cookie.

**131 backend tests pass; lint and typecheck clean. Frontend untouched and green (94 tests).**

## Follow-ups (unchanged, still their own issues)

Operator/superadmin panel (#53 phase 2), recovery command (#53 phase 3), and #56 (longer guest cookie + per-guest passwords). No gap left over from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_