### PR TITLE
Operator panel backend: sign-in, bar list, soft-delete (#53, part 1 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ machine.
 | `PUID`/`PGID` | unset, runs as root                | Run as an ordinary user instead. Ownership of the two folders is fixed on start.                                    |
 | `TRUST_PROXY` | this machine and the local network | Which proxies may say what address a guest used. Widening this would let an outsider point your QR codes elsewhere. |
 | `TZ`          | `UTC`                              | Which clock "today" is measured against, which decides what counts as today's orders.                               |
+| `OPERATOR_PASSWORD` | unset, panel off             | The password for the operator panel, which lists every bar and can retire a dead one. Leave it unset and the panel stays switched off. |
+| `SOFT_DELETE_RETENTION_DAYS` | `60`                | How many days a retired bar stays recoverable before it is removed for good.                                        |
 
 ### Putting a proxy in front
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,6 +10,7 @@ import {
   PUBLIC_URL,
   TRUST_PROXY,
   NODE_ENV,
+  OPERATOR_PASSWORD,
   type TrustProxy,
 } from "./config.js";
 import { errorReply, route } from "./http.js";
@@ -22,6 +23,7 @@ import createDrinkRoutes from "./routes/drinks.js";
 import createOrderRoutes from "./routes/orders.js";
 import createAuthRoutes from "./routes/auth.js";
 import createCategoryRoutes from "./routes/categories.js";
+import createOperatorRoutes from "./routes/operator.js";
 
 export interface AppOptions {
   db: Db;
@@ -31,6 +33,8 @@ export interface AppOptions {
   publicUrl?: string;
   trustProxy?: TrustProxy;
   requestLogging?: boolean;
+  /** The operator panel's password. Unset switches the panel off. */
+  operatorPassword?: string | undefined;
 }
 
 /**
@@ -45,6 +49,7 @@ export function createApp({
   publicUrl = PUBLIC_URL,
   trustProxy = TRUST_PROXY,
   requestLogging = NODE_ENV !== "test",
+  operatorPassword = OPERATOR_PASSWORD,
 }: AppOptions): Express {
   if (!db) throw new Error("createApp needs a database");
 
@@ -113,6 +118,7 @@ export function createApp({
   app.use("/api/orders", createOrderRoutes(db));
   app.use("/api/auth", createAuthRoutes(db));
   app.use("/api/categories", createCategoryRoutes(db));
+  app.use("/api/operator", createOperatorRoutes({ db, operatorPassword }));
 
   // Must come before the catch-all below, or unknown addresses under /api
   // would answer with a web page instead of an error.

--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -6,6 +6,7 @@ import {
   verifySession,
   type Session,
 } from "./session.js";
+import { readOperatorCookie, verifyOperator } from "./operator.js";
 
 /**
  * Resolves the cookie to a session and leaves it on `res.locals` for routes to
@@ -86,4 +87,15 @@ export function requireBarMember(res: Response, barId: number): Session {
     throw HttpError.forbidden("You can only see your own bar");
   }
   return session;
+}
+
+/**
+ * The operator, from their own cookie. Separate from the bar session, so this
+ * reads that cookie directly rather than anything `attachSession` left behind.
+ */
+export function requireOperator(req: Request): void {
+  const token = readOperatorCookie(req);
+  if (!token || !verifyOperator(token)) {
+    throw HttpError.unauthorized("Please sign in");
+  }
 }

--- a/backend/src/auth/operator.ts
+++ b/backend/src/auth/operator.ts
@@ -1,0 +1,101 @@
+import { timingSafeEqual } from "node:crypto";
+import type { Request, Response } from "express";
+
+import { COOKIE_SECURE, SESSION_TTL_MS } from "../config.js";
+import { decodeToken, encodeToken, readCookie } from "./tokens.js";
+
+// The operator's sign-in, kept apart from the bar session on purpose: its own
+// cookie, so a host can be tending a bar and be operator on the same device
+// without one signing the other out.
+
+/** The signed contents of the operator cookie. It names no bar — it sees all. */
+interface OperatorPayload {
+  v: 1;
+  role: "operator";
+  iat: number;
+  exp: number;
+}
+
+const COOKIE_NAME = "operator";
+
+/** Turns an operator sign-in into a signed cookie value. */
+export function signOperator(now: number = Date.now()): string {
+  const payload: OperatorPayload = {
+    v: 1,
+    role: "operator",
+    iat: now,
+    exp: now + SESSION_TTL_MS,
+  };
+
+  return encodeToken(payload);
+}
+
+function isOperatorPayload(
+  value: unknown,
+  now: number
+): value is OperatorPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const p = value as Record<string, unknown>;
+
+  return (
+    p["v"] === 1 &&
+    p["role"] === "operator" &&
+    typeof p["iat"] === "number" &&
+    typeof p["exp"] === "number" &&
+    p["exp"] > now
+  );
+}
+
+/** True when the cookie is one we signed and hasn't run out. */
+export function verifyOperator(
+  token: string,
+  now: number = Date.now()
+): boolean {
+  return isOperatorPayload(decodeToken(token), now);
+}
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: "lax",
+  secure: COOKIE_SECURE,
+  path: "/",
+} as const;
+
+/** Sends the signed operator cookie back on a reply. */
+export function setOperatorCookie(res: Response): void {
+  res.cookie(COOKIE_NAME, signOperator(), {
+    ...COOKIE_OPTIONS,
+    maxAge: SESSION_TTL_MS,
+  });
+}
+
+/** Clears it, on sign-out. */
+export function clearOperatorCookie(res: Response): void {
+  res.clearCookie(COOKIE_NAME, COOKIE_OPTIONS);
+}
+
+/** Reads the operator cookie out of the request, if it's there. */
+export function readOperatorCookie(req: Request): string | undefined {
+  return readCookie(req, COOKIE_NAME);
+}
+
+/**
+ * Whether the panel is switched on at all. Unset password means no operator,
+ * so the sign-in refuses and the panel can't be reached.
+ */
+export function operatorEnabled(
+  password: string | undefined
+): password is string {
+  return typeof password === "string" && password.length > 0;
+}
+
+/** A constant-time password check, so timing gives nothing away. */
+export function operatorPasswordMatches(
+  input: string,
+  expected: string
+): boolean {
+  const given = Buffer.from(input);
+  const wanted = Buffer.from(expected);
+
+  return given.length === wanted.length && timingSafeEqual(given, wanted);
+}

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -1,16 +1,8 @@
-import fs from "fs";
-import path from "path";
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { Request, Response } from "express";
 
 import type { UserType } from "../../../shared/types.js";
-import {
-  COOKIE_SECURE,
-  NODE_ENV,
-  SESSION_SECRET,
-  SESSION_SECRET_FILE,
-  SESSION_TTL_MS,
-} from "../config.js";
+import { COOKIE_SECURE, SESSION_TTL_MS } from "../config.js";
+import { decodeToken, encodeToken, readCookie } from "./tokens.js";
 
 /** Who someone is, once their cookie has been checked. */
 export interface Session {
@@ -30,46 +22,6 @@ export interface SessionPayload extends Session {
 /** The one cookie we set. */
 const COOKIE_NAME = "session";
 
-let cachedSecret: string | undefined;
-
-/**
- * The signing key. Prefer the environment; in tests keep one in memory so no
- * file is written; otherwise keep a generated one on disk so a restart doesn't
- * sign everybody out.
- */
-function secret(): string {
-  if (cachedSecret !== undefined) return cachedSecret;
-
-  if (SESSION_SECRET) {
-    cachedSecret = SESSION_SECRET;
-  } else if (NODE_ENV === "test") {
-    cachedSecret = randomBytes(32).toString("hex");
-  } else {
-    cachedSecret = readOrCreateSecretFile();
-  }
-
-  return cachedSecret;
-}
-
-function readOrCreateSecretFile(): string {
-  try {
-    const existing = fs.readFileSync(SESSION_SECRET_FILE, "utf8").trim();
-    if (existing) return existing;
-  } catch {
-    // Not there the first time; made below.
-  }
-
-  const fresh = randomBytes(32).toString("hex");
-  fs.mkdirSync(path.dirname(SESSION_SECRET_FILE), { recursive: true });
-  // Owner-only: nobody else on the box should read the signing key.
-  fs.writeFileSync(SESSION_SECRET_FILE, fresh, { mode: 0o600 });
-  return fresh;
-}
-
-function sign(body: string): string {
-  return createHmac("sha256", secret()).update(body).digest("base64url");
-}
-
 /** Turns a session into a signed cookie value. */
 export function signSession(session: Session, now: number = Date.now()): string {
   const payload: SessionPayload = {
@@ -82,8 +34,7 @@ export function signSession(session: Session, now: number = Date.now()): string 
     exp: now + SESSION_TTL_MS,
   };
 
-  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
-  return `${body}.${sign(body)}`;
+  return encodeToken(payload);
 }
 
 function isSessionPayload(value: unknown, now: number): value is SessionPayload {
@@ -106,25 +57,7 @@ export function verifySession(
   token: string,
   now: number = Date.now()
 ): SessionPayload | null {
-  const dot = token.indexOf(".");
-  if (dot <= 0) return null;
-
-  const body = token.slice(0, dot);
-  const given = Buffer.from(token.slice(dot + 1));
-  const wanted = Buffer.from(sign(body));
-
-  // Same length first, then a constant-time compare so timing gives nothing away.
-  if (given.length !== wanted.length || !timingSafeEqual(given, wanted)) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
-  } catch {
-    return null;
-  }
-
+  const parsed = decodeToken(token);
   return isSessionPayload(parsed, now) ? parsed : null;
 }
 
@@ -150,16 +83,5 @@ export function clearSessionCookie(res: Response): void {
 
 /** Reads our cookie out of the request, if it's there. */
 export function readSessionCookie(req: Request): string | undefined {
-  const header = req.headers.cookie;
-  if (!header) return undefined;
-
-  for (const part of header.split(";")) {
-    const eq = part.indexOf("=");
-    if (eq === -1) continue;
-    if (part.slice(0, eq).trim() === COOKIE_NAME) {
-      return decodeURIComponent(part.slice(eq + 1).trim());
-    }
-  }
-
-  return undefined;
+  return readCookie(req, COOKIE_NAME);
 }

--- a/backend/src/auth/tokens.ts
+++ b/backend/src/auth/tokens.ts
@@ -1,0 +1,105 @@
+import fs from "fs";
+import path from "path";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { Request } from "express";
+
+import {
+  NODE_ENV,
+  SESSION_SECRET,
+  SESSION_SECRET_FILE,
+} from "../config.js";
+
+// The signing key and the envelope around it, shared by every cookie we sign:
+// the bar session and the operator session both mint tokens the same way, so
+// the one careful HMAC and constant-time check live here rather than in two.
+
+let cachedSecret: string | undefined;
+
+/**
+ * The signing key. Prefer the environment; in tests keep one in memory so no
+ * file is written; otherwise keep a generated one on disk so a restart doesn't
+ * sign everybody out.
+ */
+function secret(): string {
+  if (cachedSecret !== undefined) return cachedSecret;
+
+  if (SESSION_SECRET) {
+    cachedSecret = SESSION_SECRET;
+  } else if (NODE_ENV === "test") {
+    cachedSecret = randomBytes(32).toString("hex");
+  } else {
+    cachedSecret = readOrCreateSecretFile();
+  }
+
+  return cachedSecret;
+}
+
+function readOrCreateSecretFile(): string {
+  try {
+    const existing = fs.readFileSync(SESSION_SECRET_FILE, "utf8").trim();
+    if (existing) return existing;
+  } catch {
+    // Not there the first time; made below.
+  }
+
+  const fresh = randomBytes(32).toString("hex");
+  fs.mkdirSync(path.dirname(SESSION_SECRET_FILE), { recursive: true });
+  // Owner-only: nobody else on the box should read the signing key.
+  fs.writeFileSync(SESSION_SECRET_FILE, fresh, { mode: 0o600 });
+  return fresh;
+}
+
+/** HMAC-SHA256 of a token body, as base64url. */
+function signBody(body: string): string {
+  return createHmac("sha256", secret()).update(body).digest("base64url");
+}
+
+/** Constant-time check that a signature belongs to a body. */
+function signatureMatches(body: string, providedSig: string): boolean {
+  const given = Buffer.from(providedSig);
+  const wanted = Buffer.from(signBody(body));
+
+  // Same length first, then a constant-time compare so timing gives nothing away.
+  return given.length === wanted.length && timingSafeEqual(given, wanted);
+}
+
+/** Wraps a payload as `base64url(json).signature`. */
+export function encodeToken(payload: unknown): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${body}.${signBody(body)}`;
+}
+
+/**
+ * Unwraps a token to its parsed payload, or null when the signature is wrong or
+ * the body isn't JSON. The caller checks the shape — this only proves we signed
+ * it and it parses.
+ */
+export function decodeToken(token: string): unknown | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+
+  const body = token.slice(0, dot);
+  if (!signatureMatches(body, token.slice(dot + 1))) return null;
+
+  try {
+    return JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Reads one named cookie off a request, if it's there. */
+export function readCookie(req: Request, name: string): string | undefined {
+  const header = req.headers.cookie;
+  if (!header) return undefined;
+
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+
+  return undefined;
+}

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -72,3 +72,15 @@ export const SESSION_SECRET_FILE = path.join(
 // Only send the cookie over HTTPS when the public address is HTTPS. Plain-http
 // development has to work without it, or the cookie never arrives.
 export const COOKIE_SECURE: boolean = PUBLIC_URL.startsWith("https://");
+
+// The password for the operator panel, which lists every bar and can retire a
+// dead one. Kept out of the database on purpose, so recovering a bar never
+// depends on the database being readable. Left unset, the panel is switched
+// off and its sign-in always refuses.
+export const OPERATOR_PASSWORD: string | undefined =
+  process.env.OPERATOR_PASSWORD || undefined;
+
+// How long a bar the operator retired sits recoverable before it is removed for
+// good. A whole row survives the wait, so a mistaken delete can be undone.
+export const SOFT_DELETE_RETENTION_DAYS: number =
+  Number(process.env.SOFT_DELETE_RETENTION_DAYS) || 60;

--- a/backend/src/db/migrations/2026-08-10-add-bar-soft-delete.sql
+++ b/backend/src/db/migrations/2026-08-10-add-bar-soft-delete.sql
@@ -1,0 +1,4 @@
+-- When the operator retires a bar it is marked here rather than removed, so a
+-- mistake can be undone. A dated purge later clears anything left past the
+-- retention window. NULL means the bar is live.
+ALTER TABLE bars ADD COLUMN deleted_at TEXT;

--- a/backend/src/db/purge.ts
+++ b/backend/src/db/purge.ts
@@ -1,0 +1,29 @@
+import { SOFT_DELETE_RETENTION_DAYS } from "../config.js";
+import { run, type Db } from "./queries.js";
+
+/**
+ * Removes bars the operator retired more than the retention window ago, for
+ * good — everything under a bar goes with it through the foreign keys. Returns
+ * how many were cleared. `now` is taken as an argument so a test can place it.
+ */
+export function purgeSoftDeleted(
+  db: Db,
+  now: number = Date.now(),
+  retentionDays: number = SOFT_DELETE_RETENTION_DAYS
+): number {
+  const days = Math.max(0, Math.floor(retentionDays));
+  const nowIso = new Date(now).toISOString();
+
+  // SQLite works out the cutoff so it comes back in the same text format the
+  // stored `deleted_at` uses, which is what makes the comparison sound.
+  const { changes } = run(
+    db,
+    `DELETE FROM bars
+     WHERE deleted_at IS NOT NULL
+       AND deleted_at < datetime(?, ?)`,
+    nowIso,
+    `-${days} days`
+  );
+
+  return changes;
+}

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -60,7 +60,14 @@ export function count(db: Db, sql: string, ...params: Params): number {
 // wording. Sharing them keeps the replies consistent.
 
 export function findBar(db: Db, barId: number): BarRow {
-  const bar = one<BarRow>(db, "SELECT * FROM bars WHERE id = ?", barId);
+  // A retired bar is gone as far as everything but the operator is concerned:
+  // it can't be signed into, ordered from, or looked up. The operator's own
+  // routes query the row directly instead of through here.
+  const bar = one<BarRow>(
+    db,
+    "SELECT * FROM bars WHERE id = ? AND deleted_at IS NULL",
+    barId
+  );
   if (!bar) throw HttpError.notFound("Bar not found");
   return bar;
 }

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -135,9 +135,10 @@ export default function createBarRoutes({
         ? requireLanguage((req.body as Record<string, unknown>)["language"])
         : "en";
 
+      // A retired bar frees its name; only a live one can clash.
       const taken = one<Pick<Bar, "id">>(
         db,
-        "SELECT id FROM bars WHERE name = ?",
+        "SELECT id FROM bars WHERE name = ? AND deleted_at IS NULL",
         name
       );
 
@@ -179,7 +180,8 @@ export default function createBarRoutes({
       res.json(
         all<Bar>(
           db,
-          `SELECT ${PUBLIC_COLUMNS} FROM bars ORDER BY created_at DESC LIMIT ?`,
+          `SELECT ${PUBLIC_COLUMNS} FROM bars
+           WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT ?`,
           limit
         )
       );

--- a/backend/src/routes/operator.ts
+++ b/backend/src/routes/operator.ts
@@ -1,0 +1,145 @@
+import express, { type Router } from "express";
+
+import type { OperatorBar } from "../../../shared/types.js";
+import {
+  HttpError,
+  idParam,
+  optionalText,
+  requireText,
+  route,
+} from "../http.js";
+import { all, one, run, type Db } from "../db/queries.js";
+import { requireOperator } from "../auth/middleware.js";
+import {
+  clearOperatorCookie,
+  operatorEnabled,
+  operatorPasswordMatches,
+  setOperatorCookie,
+} from "../auth/operator.js";
+
+interface OperatorRoutesOptions {
+  db: Db;
+  /** Left undefined when no OPERATOR_PASSWORD is set, which switches the panel off. */
+  operatorPassword?: string | undefined;
+}
+
+export default function createOperatorRoutes({
+  db,
+  operatorPassword,
+}: OperatorRoutesOptions): Router {
+  const router = express.Router();
+
+  router.post(
+    "/login",
+    route((req, res) => {
+      const password = requireText(req.body, "password");
+
+      // A panel that isn't configured and a wrong password look the same from
+      // outside, so an unset install gives nothing away.
+      if (
+        !operatorEnabled(operatorPassword) ||
+        !operatorPasswordMatches(password, operatorPassword)
+      ) {
+        throw HttpError.unauthorized("Invalid password");
+      }
+
+      setOperatorCookie(res);
+      res.json({ success: true });
+    })
+  );
+
+  router.post(
+    "/logout",
+    route((_req, res) => {
+      clearOperatorCookie(res);
+      res.json({ success: true });
+    })
+  );
+
+  // Who the operator cookie says you are. The panel checks this on load.
+  router.get(
+    "/me",
+    route((req, res) => {
+      requireOperator(req);
+      res.json({ operator: true });
+    })
+  );
+
+  // Every bar, retired ones included, live first. Its own query rather than
+  // findBar, which hides the retired ones from everyone else.
+  router.get(
+    "/bars",
+    route((req, res) => {
+      requireOperator(req);
+
+      res.json(
+        all<OperatorBar>(
+          db,
+          `SELECT
+             b.id,
+             b.name,
+             b.created_at,
+             b.deleted_at AS deletedAt,
+             (SELECT MAX(created_at) FROM orders WHERE bar_id = b.id) AS lastUsed,
+             (SELECT COUNT(*) FROM drinks WHERE bar_id = b.id) AS drinkCount,
+             (SELECT COUNT(*) FROM orders WHERE bar_id = b.id) AS orderCount
+           FROM bars b
+           ORDER BY b.deleted_at IS NOT NULL, b.created_at DESC`
+        )
+      );
+    })
+  );
+
+  // Retire a bar. It stays recoverable until the purge clears it, so this marks
+  // rather than deletes. Type-the-name, the same are-you-sure as the old delete.
+  router.delete(
+    "/bars/:id",
+    route((req, res) => {
+      requireOperator(req);
+      const barId = idParam(req, "id");
+
+      const bar = one<{ name: string }>(
+        db,
+        "SELECT name FROM bars WHERE id = ?",
+        barId
+      );
+      if (!bar) throw HttpError.notFound("Bar not found");
+
+      if (optionalText(req.body, "confirmationName") !== bar.name) {
+        throw HttpError.badRequest(
+          "Confirmation failed. Please type the exact bar name to confirm."
+        );
+      }
+
+      run(
+        db,
+        "UPDATE bars SET deleted_at = datetime('now') WHERE id = ? AND deleted_at IS NULL",
+        barId
+      );
+
+      res.json({ success: true });
+    })
+  );
+
+  // Bring a retired bar back, any time before the purge takes it for good.
+  router.post(
+    "/bars/:id/restore",
+    route((req, res) => {
+      requireOperator(req);
+      const barId = idParam(req, "id");
+
+      const bar = one<{ id: number }>(
+        db,
+        "SELECT id FROM bars WHERE id = ?",
+        barId
+      );
+      if (!bar) throw HttpError.notFound("Bar not found");
+
+      run(db, "UPDATE bars SET deleted_at = NULL WHERE id = ?", barId);
+
+      res.json({ success: true });
+    })
+  );
+
+  return router;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -11,6 +11,7 @@ import { openDatabase, closeDatabase } from "./db/index.js";
 import { createApp } from "./app.js";
 import type { Realtime } from "./realtime.js";
 import { sweepUnusedPhotos } from "./uploads.js";
+import { purgeSoftDeleted } from "./db/purge.js";
 
 const db = openDatabase(DB_PATH);
 const app = createApp({ db });
@@ -34,6 +35,23 @@ const sweepPhotos = (): void => {
 
 sweepPhotos();
 setInterval(sweepPhotos, SWEEP_EVERY_MS).unref();
+
+// A bar the operator retired sits recoverable for a while, then goes for good.
+// Checked on start and once a day, so one left past the window is cleared even
+// on a container that stays up for weeks.
+const purgeBars = (): void => {
+  try {
+    const removed = purgeSoftDeleted(db);
+    if (removed) {
+      console.log(`Removed ${removed} retired bar(s) past the retention window`);
+    }
+  } catch (error) {
+    console.error("Could not remove retired bars:", error);
+  }
+};
+
+purgeBars();
+setInterval(purgeBars, SWEEP_EVERY_MS).unref();
 
 server.listen(PORT, () => {
   console.log(`🍸 Bar running on port ${PORT}`);

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -7,6 +7,7 @@ import type { Express } from "express";
 import { openDatabase } from "../src/db/index.js";
 import { createApp } from "../src/app.js";
 import { signSession } from "../src/auth/session.js";
+import { signOperator } from "../src/auth/operator.js";
 import type { Db } from "../src/db/queries.js";
 import type { UserType } from "../../shared/types.js";
 
@@ -44,14 +45,20 @@ export interface TestApp {
 }
 
 /** The app, wired to a throwaway database and uploads folder. */
-export function makeTestApp(): TestApp {
+export function makeTestApp({
+  operatorPassword,
+}: { operatorPassword?: string } = {}): TestApp {
   const db = makeTestDatabase();
   const uploadsDir = makeTempDir("barkeep-uploads-");
   // Pointed at a folder with no web pages in it, so the tests only ever see
   // the API and never the single-page-app catch-all.
   const frontendDir = makeTempDir("barkeep-frontend-");
 
-  return { app: createApp({ db, uploadsDir, frontendDir }), db, uploadsDir };
+  return {
+    app: createApp({ db, uploadsDir, frontendDir, operatorPassword }),
+    db,
+    uploadsDir,
+  };
 }
 
 export interface SeededBar {
@@ -88,4 +95,9 @@ export function sessionCookie(session: {
   name?: string;
 }): string {
   return `session=${signSession(session)}`;
+}
+
+/** A Cookie header carrying a signed operator session. */
+export function operatorCookie(): string {
+  return `operator=${signOperator()}`;
 }

--- a/backend/tests/operator.test.ts
+++ b/backend/tests/operator.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+
+import {
+  makeTestApp,
+  cleanUpTempDirs,
+  seedBar,
+  operatorCookie,
+  sessionCookie,
+} from "./helpers.js";
+import type { Db } from "../src/db/queries.js";
+
+afterAll(cleanUpTempDirs);
+
+const PASSWORD = "back-of-house";
+
+describe("the operator panel", () => {
+  let app: Express;
+  let db: Db;
+  let barId: number;
+
+  beforeEach(() => {
+    ({ app, db } = makeTestApp({ operatorPassword: PASSWORD }));
+    ({ barId } = seedBar(db));
+  });
+
+  describe("signing in", () => {
+    it("refuses the wrong password", async () => {
+      const res = await request(app)
+        .post("/api/operator/login")
+        .send({ password: "nope" });
+      expect(res.status).toBe(401);
+    });
+
+    it("takes the right password and sets an operator cookie", async () => {
+      const res = await request(app)
+        .post("/api/operator/login")
+        .send({ password: PASSWORD });
+
+      expect(res.status).toBe(200);
+      expect(String(res.headers["set-cookie"])).toMatch(/operator=/);
+    });
+
+    it("is switched off entirely when no password is configured", async () => {
+      const { app: noPanel } = makeTestApp();
+
+      const res = await request(noPanel)
+        .post("/api/operator/login")
+        .send({ password: "anything" });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("who may reach it", () => {
+    it("turns away a request with no cookie", async () => {
+      const res = await request(app).get("/api/operator/bars");
+      expect(res.status).toBe(401);
+    });
+
+    it("turns away a bartender's cookie — it's the wrong door", async () => {
+      const res = await request(app)
+        .get("/api/operator/bars")
+        .set("Cookie", sessionCookie({ barId, role: "bartender" }));
+      expect(res.status).toBe(401);
+    });
+
+    it("lets the operator cookie in", async () => {
+      const res = await request(app)
+        .get("/api/operator/me")
+        .set("Cookie", operatorCookie());
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ operator: true });
+    });
+  });
+
+  describe("listing bars", () => {
+    it("lists every bar with when it was last used", async () => {
+      const res = await request(app)
+        .get("/api/operator/bars")
+        .set("Cookie", operatorCookie());
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).toMatchObject({
+        id: barId,
+        name: "Test Bar",
+        deletedAt: null,
+        lastUsed: null,
+      });
+    });
+  });
+
+  describe("retiring a bar", () => {
+    const retire = (name: string) =>
+      request(app)
+        .delete(`/api/operator/bars/${barId}`)
+        .set("Cookie", operatorCookie())
+        .send({ confirmationName: name });
+
+    it("needs the exact name typed to confirm", async () => {
+      expect((await retire("Wrong Name")).status).toBe(400);
+    });
+
+    it("marks the bar rather than removing it, and hides it everywhere else", async () => {
+      expect((await retire("Test Bar")).status).toBe(200);
+
+      // Gone from the public list a guest or bartender would see.
+      const list = await request(app).get("/api/bars");
+      expect(list.body).toHaveLength(0);
+
+      // Can no longer be signed into — findBar no longer finds it.
+      const signIn = await request(app)
+        .post("/api/auth/bartender")
+        .send({ barId, password: "x" });
+      expect(signIn.status).toBe(404);
+
+      // But the operator still sees it, marked with when it went.
+      const ops = await request(app)
+        .get("/api/operator/bars")
+        .set("Cookie", operatorCookie());
+      expect(ops.body).toHaveLength(1);
+      expect(ops.body[0].deletedAt).toBeTruthy();
+
+      // The row itself survives, ready to be restored.
+      const row = db
+        .prepare("SELECT deleted_at FROM bars WHERE id = ?")
+        .get(barId) as { deleted_at: string | null };
+      expect(row.deleted_at).toBeTruthy();
+    });
+
+    it("can be brought back before the purge takes it", async () => {
+      await retire("Test Bar");
+
+      const res = await request(app)
+        .post(`/api/operator/bars/${barId}/restore`)
+        .set("Cookie", operatorCookie());
+      expect(res.status).toBe(200);
+
+      const list = await request(app).get("/api/bars");
+      expect(list.body).toHaveLength(1);
+    });
+  });
+});

--- a/backend/tests/purge.test.ts
+++ b/backend/tests/purge.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterAll } from "vitest";
+
+import { makeTestDatabase, cleanUpTempDirs } from "./helpers.js";
+import { purgeSoftDeleted } from "../src/db/purge.js";
+import type { Db } from "../src/db/queries.js";
+
+afterAll(cleanUpTempDirs);
+
+/** A bar retired a given number of days ago. */
+function seedRetiredBar(db: Db, name: string, daysAgo: number): number {
+  const info = db
+    .prepare(
+      `INSERT INTO bars (name, bartender_password_hash, guest_password_hash, deleted_at)
+       VALUES (?, 'x', 'y', datetime('now', ?))`
+    )
+    .run(name, `-${daysAgo} days`);
+  return Number(info.lastInsertRowid);
+}
+
+const exists = (db: Db, id: number): boolean =>
+  db.prepare("SELECT 1 FROM bars WHERE id = ?").get(id) !== undefined;
+
+describe("purging retired bars", () => {
+  it("removes one past the window and keeps one still inside it", () => {
+    const db = makeTestDatabase();
+    const old = seedRetiredBar(db, "Long Gone", 61);
+    const recent = seedRetiredBar(db, "Just Retired", 59);
+
+    const removed = purgeSoftDeleted(db, Date.now(), 60);
+
+    expect(removed).toBe(1);
+    expect(exists(db, old)).toBe(false);
+    expect(exists(db, recent)).toBe(true);
+  });
+
+  it("never touches a live bar, even with a zero-day window", () => {
+    const db = makeTestDatabase();
+    const info = db
+      .prepare(
+        "INSERT INTO bars (name, bartender_password_hash, guest_password_hash) VALUES ('Live','x','y')"
+      )
+      .run();
+
+    const removed = purgeSoftDeleted(db, Date.now(), 0);
+
+    expect(removed).toBe(0);
+    expect(exists(db, Number(info.lastInsertRowid))).toBe(true);
+  });
+
+  it("takes everything under a purged bar with it", () => {
+    const db = makeTestDatabase();
+    const barId = seedRetiredBar(db, "With Drinks", 100);
+    db.prepare(
+      "INSERT INTO drinks (bar_id, title, recipe) VALUES (?, 'Negroni', 'gin')"
+    ).run(barId);
+
+    purgeSoftDeleted(db, Date.now(), 60);
+
+    const drinks = db
+      .prepare("SELECT COUNT(*) AS n FROM drinks WHERE bar_id = ?")
+      .get(barId) as { n: number };
+    expect(drinks.n).toBe(0);
+  });
+});

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,6 +20,12 @@ services:
       # Set this if the web address guests use differs from the one the bar
       # is reached on. QR codes use it.
       # PUBLIC_URL: https://bar.example.com
+      # The password for the operator panel, which lists every bar and can
+      # retire a dead one. Leave it unset and the panel stays switched off.
+      # OPERATOR_PASSWORD: change-me
+      # How many days a retired bar stays recoverable before it is removed for
+      # good. Defaults to 60.
+      # SOFT_DELETE_RETENTION_DAYS: 60
     healthcheck:
       test:
         [

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -109,6 +109,28 @@ export interface SignedIn {
   customerName?: string;
 }
 
+/**
+ * One bar as the operator panel sees it: enough to tell live bars apart, spot a
+ * dead one, and know when each was last used. The operator sees retired bars
+ * too, which is why `deletedAt` is here and not on the guest-facing `Bar`.
+ */
+export interface OperatorBar {
+  id: number;
+  name: string;
+  created_at: string;
+  /** The most recent order, or null if the bar has never taken one. */
+  lastUsed: string | null;
+  /** When the bar was retired, or null while it is live. */
+  deletedAt: string | null;
+  drinkCount: number;
+  orderCount: number;
+}
+
+/** The reply to `GET /api/operator/me`, or 401 with `ApiError` when not signed in. */
+export interface OperatorMe {
+  operator: true;
+}
+
 /** A printable code that takes a guest straight to the bar. */
 export interface BarQrCode {
   barId: number;


### PR DESCRIPTION
Phase 2 of #53. The operator is a second kind of sign-in — apart from a bar's bartender and guests — that can see every bar and retire a dead one. This PR is the backend only; **nothing a guest or bartender sees changes yet.** The seven-tap entry and the panel UI come in part 2.

## The operator credential

Its own password, `OPERATOR_PASSWORD`, an **environment variable never stored in the database** — so recovering a bar never depends on the database being readable, exactly as the issue argues. Left unset, the panel is switched off: `/login` refuses every password and there's no way in.

## Session

- A **separate `operator` cookie** from the bar `session` cookie, so a host can be tending a bar *and* be operator on the same device without one evicting the other. Signed and verified exactly like the bar session.
- The one HMAC + its constant-time check move into a shared `auth/tokens.ts` that both `session.ts` and the new `operator.ts` use, instead of living in two places. `session.ts` keeps its exact public API — its existing tests prove the refactor is behaviour-preserving.

## Routes — `/api/operator/*`, all behind the operator cookie

| Route | Does |
|-------|------|
| `POST /login`, `POST /logout`, `GET /me` | sign in / out, and the panel's on-load check |
| `GET /bars` | every bar, retired ones included, each with created / last-used / drink + order counts |
| `DELETE /bars/:id` | retire a bar (type-the-name to confirm) |
| `POST /bars/:id/restore` | bring one back |

## Soft-delete with a grace period

Delete is **soft**: the operator marks a bar, and it vanishes from every guest and bartender surface at once — `findBar` and the public `GET /bars` now skip retired bars (which also frees the bar's name for reuse), so a retired bar can't be signed into, ordered from, or listed. The row survives so it can be restored. A **purge** — run on start and once a day — removes bars left past the window (`SOFT_DELETE_RETENTION_DAYS`, default 60), cascading through the foreign keys. Migration `2026-08-10-add-bar-soft-delete.sql` adds `bars.deleted_at`.

## Tests

`operator.test.ts`: login refused when the panel is off; wrong vs right password; `/me` gated by the cookie; a *bartender's* cookie is turned away (wrong door); `/bars` lists with last-used; retire hides the bar from the public list and from a fresh sign-in while the operator still sees it marked; restore brings it back. `purge.test.ts`: a bar retired 61 days ago is purged, 59 days ago is kept, a live bar is never touched, and a purge cascades. I also verified the migration applies onto a database that already has bars but no `deleted_at`, keeping the data and staying idempotent.

**144 backend tests pass; lint + typecheck clean.** `OPERATOR_PASSWORD` and `SOFT_DELETE_RETENTION_DAYS` documented in `README.md` and `compose.yaml`.

## Follow-up

Part 2 (frontend): the seven-tap wordmark gesture that opens the panel with no link in the markup, and the panel UI (login, bar list, retire/restore). Password recovery remains a shell command (#53 phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_