### PR TITLE
Operator panel UI + the seven-tap way in (#53, part 2 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ services:
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads
+    environment:
+      # Switches on the operator panel (see below). Leave it out and the panel
+      # stays off; everything else runs without any settings at all.
+      OPERATOR_PASSWORD: choose-a-long-one
 ```
 
 [`compose.yaml`](compose.yaml) is the same with a healthcheck and the optional
@@ -103,6 +107,20 @@ views, which is about the right amount of security for a party in a garden.
 
 The QR code is in the settings. Show it on a screen, or print it and leave it
 on the bar.
+
+### The operator panel
+
+One screen above all the bars, for whoever runs the server: it lists every bar,
+when each was last used, and lets you retire a dead one. Switch it on by setting
+`OPERATOR_PASSWORD`; leave it unset and the panel does not exist.
+
+There is no link to it. Open the front page and tap the word **Barkeep**, top
+left, seven times — a sign-in appears. The password is the one you set, checked
+on the server; the hidden tap only keeps the door out of sight.
+
+Retiring a bar can be undone: it disappears for guests and bartenders straight
+away but can be restored, and is removed for good after
+`SOFT_DELETE_RETENTION_DAYS` (60 days by default).
 
 ### Image tags
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import DrinkForm from "./components/DrinkForm";
 import RecipeView from "./components/RecipeView";
 import ErrorDisplay from "./components/ErrorDisplay";
 import QRRedirect from "./components/QRRedirect";
+import OperatorPanel from "./components/operator/OperatorPanel";
 import { AppProvider } from "./context/AppContext";
 import { useApp } from "./hooks/useApp";
 import { LiveUpdatesProvider } from "./context/LiveUpdatesContext";
@@ -41,6 +42,9 @@ const AppContent: React.FC = () => {
     <>
       <Routes>
         <Route path="/" element={<LandingPage />} />
+        {/* The operator panel. Reached only by the hidden gesture on the
+            landing sign; it gates itself on the operator cookie. */}
+        <Route path="/operator" element={<OperatorPanel />} />
         <Route path="/bar/:id" element={<QRRedirect />} />
         <Route
           path="/customer"

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useApp } from "../hooks/useApp";
 import type { Bar, Language } from "../types";
 import { useTranslation } from "../utils/translations";
@@ -17,9 +18,25 @@ const LandingPage: React.FC = () => {
     setLoginForm,
   } = useApp();
   const t = useTranslation(language);
+  const navigate = useNavigate();
 
   const [mode, setMode] = useState<"select" | "create" | "login">("select");
   const [selectedBar, setSelectedBar] = useState<Bar | null>(null);
+
+  // The way in to the operator panel: tap the sign seven times, quickly. There
+  // is deliberately no link to it anywhere — this is the whole door. The real
+  // lock is the operator password on the other side, not the hidden gesture.
+  const taps = useRef({ count: 0, at: 0 });
+  const tapWordmark = () => {
+    const now = Date.now();
+    const run = taps.current;
+    run.count = now - run.at > 2000 ? 1 : run.count + 1;
+    run.at = now;
+    if (run.count >= 7) {
+      run.count = 0;
+      navigate("/operator");
+    }
+  };
 
   const handleSelectBar = (bar: Bar) => {
     setSelectedBar(bar);
@@ -114,7 +131,10 @@ const LandingPage: React.FC = () => {
       {/* The sign above the door. Ink in both schemes — it is the one
           deliberate block of colour in the product. */}
       <div className="lg:w-[44%] shrink-0 bg-sign text-sign-fg px-6 py-8 lg:px-10 lg:py-11 flex flex-col min-h-50 lg:min-h-screen">
-        <span className="font-mono text-caption uppercase opacity-65">
+        <span
+          onClick={tapWordmark}
+          className="font-mono text-caption uppercase opacity-65 select-none"
+        >
           Barkeep
         </span>
         <span className="flex-1" />

--- a/frontend/src/components/operator/OperatorPanel.tsx
+++ b/frontend/src/components/operator/OperatorPanel.tsx
@@ -1,0 +1,320 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Trash2, RotateCcw } from "lucide-react";
+
+import { useApp } from "../../hooks/useApp";
+import { useTranslation } from "../../utils/translations";
+import type { OperatorBar } from "../../types";
+
+const PRIMARY =
+  "h-14 px-5 rounded-md bg-text text-text-inverse text-label transition-colors duration-(--duration-instant) hover:bg-neutral-800 disabled:bg-disabled-bg disabled:text-disabled-fg disabled:cursor-not-allowed cursor-pointer";
+const DANGER =
+  "h-12 px-4 rounded-md bg-danger text-danger-contrast text-label transition-colors duration-(--duration-instant) hover:bg-danger-hover disabled:bg-disabled-bg disabled:text-disabled-fg disabled:cursor-not-allowed cursor-pointer";
+const INPUT =
+  "h-14 px-3.5 rounded-md border border-border bg-surface-raised text-body focus:outline-none focus:border-border-strong focus:shadow-focus";
+
+/** SQLite keeps times as "YYYY-MM-DD HH:MM:SS" in UTC; show just the day. */
+const asDay = (value: string | null): string | null =>
+  value ? new Date(`${value.replace(" ", "T")}Z`).toLocaleDateString() : null;
+
+const OperatorPanel: React.FC = () => {
+  const { language, apiCall } = useApp();
+  const t = useTranslation(language);
+  const navigate = useNavigate();
+
+  const [status, setStatus] = useState<"checking" | "out" | "in">("checking");
+  const [password, setPassword] = useState("");
+  const [signInError, setSignInError] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const [bars, setBars] = useState<OperatorBar[]>([]);
+  const [loadError, setLoadError] = useState(false);
+  const [confirming, setConfirming] = useState<OperatorBar | null>(null);
+
+  const loadBars = useCallback(async () => {
+    try {
+      setBars(await apiCall<OperatorBar[]>("/operator/bars"));
+      setLoadError(false);
+    } catch {
+      setLoadError(true);
+    }
+  }, [apiCall]);
+
+  // Ask the server, on load, whether this browser already holds an operator
+  // cookie. A 401 just means "show the sign-in".
+  useEffect(() => {
+    let live = true;
+    apiCall("/operator/me")
+      .then(() => live && setStatus("in"))
+      .catch(() => live && setStatus("out"));
+    return () => {
+      live = false;
+    };
+  }, [apiCall]);
+
+  useEffect(() => {
+    if (status === "in") void loadBars();
+  }, [status, loadBars]);
+
+  const signIn = async () => {
+    if (!password) return;
+    setBusy(true);
+    setSignInError(false);
+    try {
+      await apiCall("/operator/login", {
+        method: "POST",
+        body: JSON.stringify({ password }),
+      });
+      setPassword("");
+      setStatus("in");
+    } catch {
+      setSignInError(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const signOut = async () => {
+    await apiCall("/operator/logout", { method: "POST" }).catch(() => {});
+    navigate("/");
+  };
+
+  const remove = async (bar: OperatorBar, confirmationName: string) => {
+    setBusy(true);
+    try {
+      await apiCall(`/operator/bars/${bar.id}`, {
+        method: "DELETE",
+        body: JSON.stringify({ confirmationName }),
+      });
+      setConfirming(null);
+      await loadBars();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const restore = async (bar: OperatorBar) => {
+    setBusy(true);
+    try {
+      await apiCall(`/operator/bars/${bar.id}/restore`, { method: "POST" });
+      await loadBars();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (status === "checking") {
+    return (
+      <div className="min-h-screen bg-surface flex items-center justify-center">
+        <p className="text-body text-text-muted">{t("loading")}</p>
+      </div>
+    );
+  }
+
+  if (status === "out") {
+    return (
+      <div className="min-h-screen bg-surface flex items-center justify-center px-6">
+        <div className="w-full max-w-sm space-y-5">
+          <div>
+            <h1 className="text-display">{t("operatorTitle")}</h1>
+            <p className="text-body text-text-muted mt-1">{t("operatorIntro")}</p>
+          </div>
+
+          <input
+            type="password"
+            autoFocus
+            value={password}
+            placeholder={t("operatorPasswordPlaceholder")}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && signIn()}
+            className={`w-full ${INPUT}`}
+          />
+
+          {signInError && (
+            <p className="text-body text-danger">{t("operatorWrongPassword")}</p>
+          )}
+
+          <button
+            type="button"
+            onClick={signIn}
+            disabled={busy || !password}
+            className={`w-full ${PRIMARY}`}
+          >
+            {t("operatorSignIn")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-surface px-6 py-8 lg:px-10 lg:py-9">
+      <div className="max-w-3xl mx-auto space-y-5">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-display">{t("operatorTitle")}</h1>
+            <p className="text-body text-text-muted mt-1">{t("operatorIntro")}</p>
+          </div>
+          <button
+            type="button"
+            onClick={signOut}
+            className="h-12 px-4 rounded-md border border-border text-label text-text-muted transition-colors duration-(--duration-instant) hover:text-text cursor-pointer"
+          >
+            {t("operatorSignOut")}
+          </button>
+        </div>
+
+        {loadError ? (
+          <p className="text-body text-danger">{t("operatorLoadError")}</p>
+        ) : bars.length === 0 ? (
+          <div className="flex flex-col items-center gap-2.5 py-10 px-5 bg-surface-raised border border-border rounded-md text-center">
+            <p className="text-body text-text-muted max-w-[44ch]">
+              {t("operatorNoBars")}
+            </p>
+          </div>
+        ) : (
+          <div className="bg-surface border border-border rounded-md overflow-hidden">
+            <div className="px-5 py-4 border-b border-border">
+              <h2 className="text-heading">{t("operatorBars")}</h2>
+            </div>
+
+            <ul>
+              {bars.map((bar) => {
+                const retired = bar.deletedAt !== null;
+                const lastUsed = asDay(bar.lastUsed);
+                return (
+                  <li
+                    key={bar.id}
+                    className="flex items-center gap-4 px-5 py-4 border-b border-border last:border-b-0"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p
+                        className={`text-label truncate ${retired ? "text-text-muted line-through" : "text-text"}`}
+                      >
+                        {bar.name}
+                      </p>
+                      <p className="font-mono text-caption uppercase text-text-muted mt-0.5">
+                        {t("operatorCreated")} {asDay(bar.created_at)}
+                        {" · "}
+                        {t("operatorLastUsed")}{" "}
+                        {lastUsed ?? t("operatorNeverUsed")}
+                        {" · "}
+                        {bar.drinkCount} {t("operatorDrinks")}
+                        {" · "}
+                        {bar.orderCount} {t("operatorOrders")}
+                        {retired && (
+                          <>
+                            {" · "}
+                            {t("operatorRemovedOnPrefix")} {asDay(bar.deletedAt)}
+                          </>
+                        )}
+                      </p>
+                    </div>
+
+                    {retired ? (
+                      <button
+                        type="button"
+                        onClick={() => restore(bar)}
+                        disabled={busy}
+                        className="h-12 px-4 shrink-0 flex items-center gap-1.5 rounded-md border border-border text-label transition-colors duration-(--duration-instant) hover:bg-surface-sunken disabled:cursor-not-allowed cursor-pointer"
+                      >
+                        <RotateCcw className="w-4 h-4" />
+                        {t("operatorRestore")}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        aria-label={`${t("operatorRemove")} ${bar.name}`}
+                        onClick={() => setConfirming(bar)}
+                        className="h-12 w-12 shrink-0 flex items-center justify-center rounded-md border border-border text-danger transition-colors duration-(--duration-instant) hover:bg-surface-sunken cursor-pointer"
+                      >
+                        <Trash2 className="w-4.5 h-4.5" />
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {confirming && (
+        <ConfirmRemoval
+          bar={confirming}
+          busy={busy}
+          onCancel={() => setConfirming(null)}
+          onConfirm={(name) => remove(confirming, name)}
+        />
+      )}
+    </div>
+  );
+};
+
+interface ConfirmRemovalProps {
+  bar: OperatorBar;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (confirmationName: string) => void;
+}
+
+/** Type-the-name before a bar is retired, so it can't happen by a stray tap. */
+const ConfirmRemoval: React.FC<ConfirmRemovalProps> = ({
+  bar,
+  busy,
+  onCancel,
+  onConfirm,
+}) => {
+  const { language } = useApp();
+  const t = useTranslation(language);
+  const [typed, setTyped] = useState("");
+  const matches = typed === bar.name;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-overlay flex items-start justify-center p-4 pt-24 overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("operatorConfirmTitle")}
+        className="w-full max-w-md bg-surface-raised border border-border rounded-lg shadow-float overflow-hidden"
+      >
+        <div className="px-5 py-4 border-b border-border">
+          <h2 className="text-display">{t("operatorConfirmTitle")}</h2>
+        </div>
+
+        <div className="px-5 py-4 space-y-4">
+          <p className="text-body text-text-muted">{t("operatorConfirmBody")}</p>
+          <input
+            type="text"
+            autoFocus
+            value={typed}
+            placeholder={bar.name}
+            onChange={(e) => setTyped(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && matches && onConfirm(typed)}
+            className={`w-full ${INPUT}`}
+          />
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex justify-end gap-2.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-12 px-4 rounded-md border border-border text-label text-text-muted transition-colors duration-(--duration-instant) hover:text-text cursor-pointer"
+          >
+            {t("cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(typed)}
+            disabled={busy || !matches}
+            className={DANGER}
+          >
+            {t("operatorConfirmButton")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OperatorPanel;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,7 @@ export type {
   Flag,
   Language,
   LiveUpdate,
+  OperatorBar,
   OrderStatus,
   SignedIn,
   UserType,

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -232,6 +232,29 @@ export interface TranslationMap {
   connectionLostBody: string;
   connectionLostRetry: string;
   connectionLostDismiss: string;
+
+  // Operator panel
+  operatorTitle: string;
+  operatorIntro: string;
+  operatorPasswordPlaceholder: string;
+  operatorSignIn: string;
+  operatorWrongPassword: string;
+  operatorSignOut: string;
+  operatorBars: string;
+  operatorCreated: string;
+  operatorLastUsed: string;
+  operatorNeverUsed: string;
+  operatorDrinks: string;
+  operatorOrders: string;
+  operatorRemove: string;
+  operatorRestore: string;
+  operatorRetiredTag: string;
+  operatorRemovedOnPrefix: string;
+  operatorConfirmTitle: string;
+  operatorConfirmBody: string;
+  operatorConfirmButton: string;
+  operatorNoBars: string;
+  operatorLoadError: string;
 }
 
 export const translations: { en: TranslationMap; da: TranslationMap } = {
@@ -477,6 +500,28 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
       "You may not see new orders until this comes back. It usually sorts itself out in a moment.",
     connectionLostRetry: "Try again now",
     connectionLostDismiss: "Carry on anyway",
+    operatorTitle: "Operator",
+    operatorIntro: "Every bar on this server.",
+    operatorPasswordPlaceholder: "Operator password",
+    operatorSignIn: "Sign in",
+    operatorWrongPassword: "That password did not work.",
+    operatorSignOut: "Sign out",
+    operatorBars: "Bars",
+    operatorCreated: "Created",
+    operatorLastUsed: "Last used",
+    operatorNeverUsed: "Never used",
+    operatorDrinks: "drinks",
+    operatorOrders: "orders",
+    operatorRemove: "Remove",
+    operatorRestore: "Restore",
+    operatorRetiredTag: "Removed",
+    operatorRemovedOnPrefix: "Removed on",
+    operatorConfirmTitle: "Remove this bar?",
+    operatorConfirmBody:
+      "It disappears for guests and bartenders straight away, but can be restored until it is removed for good. Type the bar's name to confirm.",
+    operatorConfirmButton: "Remove bar",
+    operatorNoBars: "No bars on this server yet.",
+    operatorLoadError: "Could not load the bars.",
   },
   da: {
     // Landing page (Danish)
@@ -720,6 +765,28 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
       "Du ser måske ikke nye bestillinger, før forbindelsen er tilbage. Det plejer at løse sig af sig selv.",
     connectionLostRetry: "Prøv igen nu",
     connectionLostDismiss: "Fortsæt alligevel",
+    operatorTitle: "Operatør",
+    operatorIntro: "Alle barer på denne server.",
+    operatorPasswordPlaceholder: "Operatøradgangskode",
+    operatorSignIn: "Log ind",
+    operatorWrongPassword: "Den adgangskode virkede ikke.",
+    operatorSignOut: "Log ud",
+    operatorBars: "Barer",
+    operatorCreated: "Oprettet",
+    operatorLastUsed: "Sidst brugt",
+    operatorNeverUsed: "Aldrig brugt",
+    operatorDrinks: "drinks",
+    operatorOrders: "bestillinger",
+    operatorRemove: "Fjern",
+    operatorRestore: "Gendan",
+    operatorRetiredTag: "Fjernet",
+    operatorRemovedOnPrefix: "Fjernet den",
+    operatorConfirmTitle: "Fjern denne bar?",
+    operatorConfirmBody:
+      "Den forsvinder for gæster og bartendere med det samme, men kan gendannes indtil den slettes endeligt. Skriv barens navn for at bekræfte.",
+    operatorConfirmButton: "Fjern bar",
+    operatorNoBars: "Ingen barer på denne server endnu.",
+    operatorLoadError: "Kunne ikke hente barerne.",
   },
 };
 

--- a/frontend/tests/operator.test.tsx
+++ b/frontend/tests/operator.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+import { AppProvider } from "../src/context/AppContext";
+import LandingPage from "../src/components/LandingPage";
+import OperatorPanel from "../src/components/operator/OperatorPanel";
+import { fakeApi, type FakeApi } from "./helpers";
+import type { OperatorBar } from "../src/types";
+
+const aBarRow = (extra: Partial<OperatorBar> = {}): OperatorBar => ({
+  id: 1,
+  name: "Downstairs",
+  created_at: "2025-07-13 14:23:32",
+  lastUsed: "2025-07-14 20:10:00",
+  deletedAt: null,
+  drinkCount: 4,
+  orderCount: 12,
+  ...extra,
+});
+
+/** Answers the operator endpoints, and the landing page's bar list. */
+function operatorApi(bars: OperatorBar[] = [aBarRow()]): FakeApi {
+  return fakeApi((path, options) => {
+    if (path.includes("/operator/me")) return undefined; // no cookie → 401
+    if (path.includes("/operator/login")) return { success: true };
+    if (path.includes("/operator/logout")) return { success: true };
+    if (path.includes("/operator/bars")) {
+      return options.method === "DELETE" || options.method === "POST"
+        ? { success: true }
+        : bars;
+    }
+    if (path.includes("/bars")) return []; // the landing bar picker
+    return undefined;
+  });
+}
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppProvider>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/operator" element={<OperatorPanel />} />
+        </Routes>
+      </AppProvider>
+    </MemoryRouter>
+  );
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("the hidden way in", () => {
+  it("opens the operator door after seven taps on the sign", async () => {
+    operatorApi();
+    renderAt("/");
+
+    const sign = screen.getByText("Barkeep");
+    for (let i = 0; i < 7; i++) fireEvent.click(sign);
+
+    // The operator sign-in appears — its own screen, reached with no link.
+    expect(
+      await screen.findByPlaceholderText("Operator password")
+    ).toBeInTheDocument();
+  });
+
+  it("stays shut on only six taps", () => {
+    operatorApi();
+    renderAt("/");
+
+    const sign = screen.getByText("Barkeep");
+    for (let i = 0; i < 6; i++) fireEvent.click(sign);
+
+    expect(screen.queryByPlaceholderText("Operator password")).toBeNull();
+  });
+});
+
+describe("the operator panel", () => {
+  it("signs in and lists the bars", async () => {
+    operatorApi([aBarRow({ name: "The Cellar" })]);
+    renderAt("/operator");
+
+    fireEvent.change(await screen.findByPlaceholderText("Operator password"), {
+      target: { value: "back-of-house" },
+    });
+    fireEvent.click(screen.getByText("Sign in"));
+
+    expect(await screen.findByText("The Cellar")).toBeInTheDocument();
+  });
+
+  it("won't retire a bar until its exact name is typed", async () => {
+    const api = operatorApi([aBarRow({ name: "The Cellar" })]);
+    renderAt("/operator");
+
+    fireEvent.change(await screen.findByPlaceholderText("Operator password"), {
+      target: { value: "back-of-house" },
+    });
+    fireEvent.click(screen.getByText("Sign in"));
+    await screen.findByText("The Cellar");
+
+    // Open the type-the-name confirmation.
+    fireEvent.click(screen.getByLabelText("Remove The Cellar"));
+
+    const confirm = await screen.findByText("Remove bar");
+    expect(confirm).toBeDisabled();
+
+    // The wrong name keeps it disabled.
+    fireEvent.change(screen.getByPlaceholderText("The Cellar"), {
+      target: { value: "the cellar" },
+    });
+    expect(confirm).toBeDisabled();
+
+    // The exact name arms it, and firing sends the delete with the name.
+    fireEvent.change(screen.getByPlaceholderText("The Cellar"), {
+      target: { value: "The Cellar" },
+    });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      const del = api.calls.find((c) => c.method === "DELETE");
+      expect(del?.body).toEqual({ confirmationName: "The Cellar" });
+    });
+  });
+});


### PR DESCRIPTION
The frontend half of the operator panel (#53 phase 2). Builds on the backend from #61, now on `staging`.

## The hidden entrance

Tapping the **Barkeep** wordmark on the landing sign seven times, quickly, opens the panel. There is **no link to it anywhere in the markup** — the seventh tap calls `navigate("/operator")` in code, the way Android reveals developer options. This only keeps the door out of sight; the real lock is the operator password checked on the server, which this screen has no way around. (The `/operator` path does exist in the JS bundle — obscurity for the entrance, not the security boundary.)

## The panel

`/operator` gates itself on the operator cookie: it asks the server on load, shows a password sign-in when there's no cookie, and otherwise lists every bar with when it was created, when it was last used, and its drink and order counts. A live bar can be retired behind a **type-the-name** confirmation; a retired bar shows muted, with the date it went and a **Restore** button — the delete is soft and reversible until the purge takes it.

Styling reuses the existing design tokens and component patterns (`SettingsTab`'s card + input, `RandomDrinkModal`'s dialog, the danger button role). `OperatorBar` comes through `shared/types` — nothing hand-writes an API shape.

## Docs

Per request, `README.md` now shows `OPERATOR_PASSWORD` in the run example and has a short "operator panel" section: what it does, the env var that switches it on, the seven-tap entry, and the recoverable-until-`SOFT_DELETE_RETENTION_DAYS` behaviour.

## Tests

`frontend/tests/operator.test.tsx`: seven taps open the door, six don't, sign-in lists the bars, and retire won't fire until the exact name is typed (and then sends it). **98 frontend tests pass; lint, typecheck, and build all clean.**

## One thing for review

The **Danish strings are a first pass** and want a native read before release — that's the one place I guessed rather than knew. Everything else mirrors shapes the server already defines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_