### PR TITLE
Add a reset-code command for a lost password (#53, phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Retiring a bar can be undone: it disappears for guests and bartenders straight
 away but can be restored, and is removed for good after
 `SOFT_DELETE_RETENTION_DAYS` (60 days by default).
 
+### If a code is lost
+
+Recovering a password does not need a screen — it needs the machine. From the
+server, set a new code and read it once:
+
+```sh
+docker compose exec barkeep npm run reset-code -- --bar 1 --guest
+docker compose exec barkeep npm run reset-code -- --bar 1 --bartender
+```
+
+The bar's id is on the operator panel. The new code is shown once and only its
+hash is kept, so write it down when it appears. This works even when the app
+will not start, because it never starts it.
+
 ### Image tags
 
 | Tag              | Built from                                     |

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "build": "tsc && node scripts/copy-sql.js",
     "start": "node dist/server.js",
     "init-db": "tsx src/db/init.ts",
+    "reset-code": "node dist/cli/reset-code.js",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/backend/src/cli/reset-code.ts
+++ b/backend/src/cli/reset-code.ts
@@ -1,0 +1,81 @@
+import { pathToFileURL } from "node:url";
+
+import { openDatabase, closeDatabase } from "../db/index.js";
+import { DB_PATH } from "../config.js";
+import { resetBarPassword, type PasswordRole } from "../passwords/reset.js";
+
+// Recovering a lost code from the machine itself. Whoever runs this already has
+// the server's files, which is the right proof for "I have lost the password" —
+// and it works even when the app won't start, because it never starts it.
+
+const USAGE = `Set a new password for one bar and print it once.
+
+  npm run reset-code -- --bar <id> --guest
+  npm run reset-code -- --bar <id> --bartender
+
+Use it when a code has been lost. The new code is shown once and only its hash
+is kept, so write it down when it appears.`;
+
+interface ResetRequest {
+  barId: number;
+  role: PasswordRole;
+}
+
+/** Reads the request out of the command line, or explains what's missing. */
+export function parseResetArgs(argv: string[]): ResetRequest | { help: true } {
+  if (argv.includes("--help") || argv.includes("-h")) return { help: true };
+
+  const barAt = argv.indexOf("--bar");
+  const barId = barAt === -1 ? NaN : Number(argv[barAt + 1]);
+
+  const guest = argv.includes("--guest");
+  const bartender = argv.includes("--bartender");
+
+  if (!Number.isInteger(barId) || barId <= 0) {
+    throw new Error("Which bar? Pass --bar <id> with a whole number.");
+  }
+  if (guest === bartender) {
+    throw new Error("Which code? Pass exactly one of --guest or --bartender.");
+  }
+
+  return { barId, role: guest ? "guest" : "bartender" };
+}
+
+async function main(): Promise<void> {
+  const parsed = parseResetArgs(process.argv.slice(2));
+
+  if ("help" in parsed) {
+    console.log(USAGE);
+    return;
+  }
+
+  const db = openDatabase(DB_PATH);
+  try {
+    const { barName, code } = await resetBarPassword(
+      db,
+      parsed.barId,
+      parsed.role
+    );
+    const which = parsed.role === "guest" ? "Guest" : "Bartender";
+
+    console.log(`\n${which} code for "${barName}" is now:\n`);
+    console.log(`    ${code}\n`);
+    console.log("Shown once — write it down. Only its hash is stored.\n");
+  } finally {
+    closeDatabase(db);
+  }
+}
+
+// Only run when this file is the program, so a test can import parseResetArgs
+// without opening a database.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error("Run with --help for usage.");
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/passwords/reset.ts
+++ b/backend/src/passwords/reset.ts
@@ -1,0 +1,57 @@
+import { randomInt } from "node:crypto";
+import bcrypt from "bcrypt";
+
+import { one, run, type Db } from "../db/queries.js";
+
+// Setting a lost password back to something known. Kept as a plain function so
+// the recovery command can use it today and an operator route could use the
+// very same thing later — neither has to know how the other shows the result.
+
+const HASH_ROUNDS = 12;
+
+// No look-alike characters (no i, l, o, 0, 1), so a code read off a screen and
+// typed on a phone doesn't trip on which letter it was.
+const ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789";
+const CODE_LENGTH = 10;
+
+export type PasswordRole = "bartender" | "guest";
+
+const COLUMN: Record<PasswordRole, string> = {
+  bartender: "bartender_password_hash",
+  guest: "guest_password_hash",
+};
+
+/** A fresh, readable code: random, no look-alikes, shown in two short groups. */
+export function generateResetCode(): string {
+  let raw = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    raw += ALPHABET.charAt(randomInt(ALPHABET.length));
+  }
+  return `${raw.slice(0, 5)}-${raw.slice(5)}`;
+}
+
+/**
+ * Sets a new password for one bar and hands back the plaintext once. Only the
+ * hash is stored; the code itself is never written down anywhere, so the caller
+ * has to show it there and then. Throws if there is no such bar.
+ */
+export async function resetBarPassword(
+  db: Db,
+  barId: number,
+  role: PasswordRole
+): Promise<{ barName: string; code: string }> {
+  const bar = one<{ name: string }>(
+    db,
+    "SELECT name FROM bars WHERE id = ?",
+    barId
+  );
+  if (!bar) throw new Error(`No bar with id ${barId}.`);
+
+  const code = generateResetCode();
+  const hash = await bcrypt.hash(code, HASH_ROUNDS);
+
+  // The column is chosen from a fixed pair by a typed role, never from input.
+  run(db, `UPDATE bars SET ${COLUMN[role]} = ? WHERE id = ?`, hash, barId);
+
+  return { barName: bar.name, code };
+}

--- a/backend/tests/reset.test.ts
+++ b/backend/tests/reset.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterAll } from "vitest";
+import bcrypt from "bcrypt";
+
+import { makeTestDatabase, cleanUpTempDirs } from "./helpers.js";
+import { resetBarPassword, generateResetCode } from "../src/passwords/reset.js";
+import { parseResetArgs } from "../src/cli/reset-code.js";
+import type { Db } from "../src/db/queries.js";
+
+afterAll(cleanUpTempDirs);
+
+/** A bar whose two codes we know, so we can prove which one changed. */
+function seedWithKnownCodes(db: Db): number {
+  const info = db
+    .prepare(
+      "INSERT INTO bars (name, bartender_password_hash, guest_password_hash) VALUES ('Test Bar', ?, ?)"
+    )
+    .run(bcrypt.hashSync("old-bartender", 8), bcrypt.hashSync("old-guest", 8));
+  return Number(info.lastInsertRowid);
+}
+
+const hashesOf = (db: Db, barId: number) =>
+  db
+    .prepare(
+      "SELECT bartender_password_hash AS b, guest_password_hash AS g FROM bars WHERE id = ?"
+    )
+    .get(barId) as { b: string; g: string };
+
+describe("resetting a bar's password", () => {
+  it("sets a new guest code and leaves the bartender's alone", async () => {
+    const db = makeTestDatabase();
+    const barId = seedWithKnownCodes(db);
+
+    const { code, barName } = await resetBarPassword(db, barId, "guest");
+    expect(barName).toBe("Test Bar");
+
+    const { b, g } = hashesOf(db, barId);
+    // The printed code is the new guest code...
+    expect(bcrypt.compareSync(code, g)).toBe(true);
+    // ...the old guest code no longer works...
+    expect(bcrypt.compareSync("old-guest", g)).toBe(false);
+    // ...and the bartender code is untouched.
+    expect(bcrypt.compareSync("old-bartender", b)).toBe(true);
+  });
+
+  it("sets a new bartender code and leaves the guest's alone", async () => {
+    const db = makeTestDatabase();
+    const barId = seedWithKnownCodes(db);
+
+    const { code } = await resetBarPassword(db, barId, "bartender");
+
+    const { b, g } = hashesOf(db, barId);
+    expect(bcrypt.compareSync(code, b)).toBe(true);
+    expect(bcrypt.compareSync("old-guest", g)).toBe(true);
+  });
+
+  it("refuses a bar that isn't there", async () => {
+    const db = makeTestDatabase();
+    await expect(resetBarPassword(db, 9999, "guest")).rejects.toThrow(/no bar/i);
+  });
+});
+
+describe("the reset code itself", () => {
+  it("is two groups of look-alike-free characters", () => {
+    expect(generateResetCode()).toMatch(/^[a-hj-np-z2-9]{5}-[a-hj-np-z2-9]{5}$/);
+  });
+
+  it("is different each time", () => {
+    expect(generateResetCode()).not.toBe(generateResetCode());
+  });
+});
+
+describe("reading the command line", () => {
+  it("takes a bar and a guest/bartender choice", () => {
+    expect(parseResetArgs(["--bar", "3", "--guest"])).toEqual({
+      barId: 3,
+      role: "guest",
+    });
+    expect(parseResetArgs(["--bartender", "--bar", "1"])).toEqual({
+      barId: 1,
+      role: "bartender",
+    });
+  });
+
+  it("asks for a bar when none is given", () => {
+    expect(() => parseResetArgs(["--guest"])).toThrow(/which bar/i);
+  });
+
+  it("asks for exactly one role", () => {
+    expect(() => parseResetArgs(["--bar", "1"])).toThrow(/which code/i);
+    expect(() =>
+      parseResetArgs(["--bar", "1", "--guest", "--bartender"])
+    ).toThrow(/which code/i);
+  });
+
+  it("offers help when asked", () => {
+    expect(parseResetArgs(["--help"])).toEqual({ help: true });
+  });
+});


### PR DESCRIPTION
The last of the #53 auth work. Recovering a bar's password is a **command on the server**, not a web screen — as the issue argues: whoever runs it already has the machine's files, which is the right proof for "I have lost the password," and it works even when the app won't start because it never starts it.

```sh
npm run reset-code -- --bar 1 --guest
npm run reset-code -- --bar 1 --bartender
```

It sets a new code, prints it **once**, and stores only the hash. The code is drawn from a look-alike-free alphabet (no `i l o 0 1`) and shown in two short groups, so it survives being read off a screen and typed on a phone.

## Built to be wired up later

The reset itself is a plain function — `resetBarPassword(db, barId, role)` in `src/passwords/reset.ts` — that finds the bar, generates a code, hashes it, updates the right column, and returns `{ barName, code }`. The command (`src/cli/reset-code.ts`) is a thin wrapper: parse args → open the DB → call the function → print. So an operator route could call the *same* function tomorrow and just render the result differently — no logic moves. The CLI guards its entry point (`import.meta.url` check) so importing it for a test never opens a database.

## Tests

`reset.test.ts`: resetting the guest code changes only the guest hash (the new code verifies via bcrypt, the old one stops working, the bartender's is untouched) and vice versa; an unknown bar throws; the code matches the look-alike-free shape and differs each call; and the argument parser handles bar/role/help and the missing-or-ambiguous cases. **153 backend tests pass; lint + typecheck clean.**

I also ran it for real: built to `dist`, seeded a bar, and `node dist/cli/reset-code.js --bar 1 --guest` printed a fresh code after applying migrations — the container path (`docker compose exec barkeep npm run reset-code -- …`) works the same way.

## Docs

`README.md` gains a short "if a code is lost" section with the two commands and a note that the bar's id is on the operator panel.

With this, #53 is complete end to end: sessions → mutation + read lockdown → operator panel → recovery command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqWYm2bFcVCAdUwUHMKsh)_