### PR TITLE
Let regulars claim their name with a password (#56)

### DIFF
--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -36,6 +36,16 @@ function supplied(password: string | undefined): string | undefined {
   return password && password.length > 0 ? password : undefined;
 }
 
+/** A SQLite unique-constraint error, as thrown when a name is claimed twice. */
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    String((err as { code: unknown }).code).includes("CONSTRAINT")
+  );
+}
+
 /**
  * Settles who a guest is before we hand them a session.
  *
@@ -81,9 +91,11 @@ export async function resolveGuest(
         name,
         passwordHash
       );
-    } catch {
-      // Someone claimed the same name between our look-up and this insert.
-      // Treat it like any other claimed name — the password they set isn't it.
+    } catch (err) {
+      // The one expected failure is the unique name: someone claimed it between
+      // our look-up and this insert. Treat that like any other claimed name;
+      // let a real database fault surface as itself rather than a fib.
+      if (!isUniqueViolation(err)) throw err;
       throw new HttpError(409, "That name was just claimed", NAME_CLAIMED);
     }
 

--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -1,7 +1,15 @@
 import bcrypt from "bcrypt";
 
+import type { Regular } from "../../../shared/types.js";
 import { HttpError } from "../http.js";
-import { findGuestAccount, run, type Db } from "../db/queries.js";
+import {
+  all,
+  findGuestAccount,
+  one,
+  run,
+  type Db,
+  type GuestAccountRow,
+} from "../db/queries.js";
 
 // Matches the bar-password hashing elsewhere, kept local like those.
 const HASH_ROUNDS = 12;
@@ -110,4 +118,81 @@ export async function changeGuestPassword(
 
   const passwordHash = await bcrypt.hash(newPassword, HASH_ROUNDS);
   run(db, "UPDATE guest_accounts SET password_hash = ? WHERE id = ?", passwordHash, account.id);
+}
+
+/** The regulars a bar has, for the bartender's list. No hashes leave here. */
+export function listRegulars(db: Db, barId: number): Regular[] {
+  return all<Regular>(
+    db,
+    `SELECT id, name, created_at FROM guest_accounts
+     WHERE bar_id = ? ORDER BY name COLLATE NOCASE`,
+    barId
+  );
+}
+
+/**
+ * Renames a regular, carrying their name-keyed favourites and past orders over
+ * with them so nothing is left behind. For the bartender to fix a name or tell
+ * two same-named regulars apart — the guest is told their new name next visit.
+ */
+export function renameRegular(
+  db: Db,
+  barId: number,
+  accountId: number,
+  newName: string
+): Regular {
+  const account = one<GuestAccountRow>(
+    db,
+    "SELECT * FROM guest_accounts WHERE id = ? AND bar_id = ?",
+    accountId,
+    barId
+  );
+  if (!account) throw HttpError.notFound("No such regular");
+
+  const trimmed = newName.trim();
+  if (trimmed.length < 2) {
+    throw HttpError.badRequest("Name must be at least 2 characters long");
+  }
+
+  // A rename can't land on a name another regular has already claimed. The same
+  // account under a different casing is fine, so fixing the case is allowed.
+  const clash = findGuestAccount(db, barId, trimmed);
+  if (clash && clash.id !== account.id) {
+    throw new HttpError(409, "That name is already taken", NAME_CLAIMED);
+  }
+
+  const oldName = account.name;
+
+  db.transaction(() => {
+    run(db, "UPDATE guest_accounts SET name = ? WHERE id = ?", trimmed, account.id);
+
+    // Favourites carry a per-drink uniqueness, so move what can move and drop
+    // any leftover that would duplicate one already under the new name.
+    run(
+      db,
+      `UPDATE OR IGNORE user_favourites SET customer_name = ?
+       WHERE bar_id = ? AND customer_name = ? COLLATE NOCASE`,
+      trimmed,
+      barId,
+      oldName
+    );
+    run(
+      db,
+      `DELETE FROM user_favourites
+       WHERE bar_id = ? AND customer_name = ? COLLATE NOCASE`,
+      barId,
+      oldName
+    );
+
+    run(
+      db,
+      `UPDATE orders SET customer_name = ?
+       WHERE bar_id = ? AND customer_name = ? COLLATE NOCASE`,
+      trimmed,
+      barId,
+      oldName
+    );
+  })();
+
+  return { id: account.id, name: trimmed, created_at: account.created_at };
 }

--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -196,3 +196,34 @@ export function renameRegular(
 
   return { id: account.id, name: trimmed, created_at: account.created_at };
 }
+
+/**
+ * Sets a regular's password on the bartender's say-so — no old password asked
+ * for. The bartender hands the tablet over for the guest to type their own, or
+ * sets a simple one the guest changes later. A friendly way back in for a
+ * regular who forgot theirs.
+ */
+export async function setRegularPassword(
+  db: Db,
+  barId: number,
+  accountId: number,
+  newPassword: string
+): Promise<void> {
+  const account = one<GuestAccountRow>(
+    db,
+    "SELECT * FROM guest_accounts WHERE id = ? AND bar_id = ?",
+    accountId,
+    barId
+  );
+  if (!account) throw HttpError.notFound("No such regular");
+
+  const trimmed = newPassword.trim();
+  if (trimmed.length < GUEST_PASSWORD_MIN) {
+    throw HttpError.badRequest(
+      `Password must be at least ${GUEST_PASSWORD_MIN} characters long`
+    );
+  }
+
+  const passwordHash = await bcrypt.hash(trimmed, HASH_ROUNDS);
+  run(db, "UPDATE guest_accounts SET password_hash = ? WHERE id = ?", passwordHash, account.id);
+}

--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -1,6 +1,7 @@
 import bcrypt from "bcrypt";
 
 import type { Regular } from "../../../shared/types.js";
+import { HASH_ROUNDS } from "../config.js";
 import { HttpError } from "../http.js";
 import {
   all,
@@ -10,9 +11,6 @@ import {
   type Db,
   type GuestAccountRow,
 } from "../db/queries.js";
-
-// Matches the bar-password hashing elsewhere, kept local like those.
-const HASH_ROUNDS = 12;
 
 /** The shortest a claimed-name password may be. Light, for a party app. */
 export const GUEST_PASSWORD_MIN = 4;

--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -1,0 +1,113 @@
+import bcrypt from "bcrypt";
+
+import { HttpError } from "../http.js";
+import { findGuestAccount, run, type Db } from "../db/queries.js";
+
+// Matches the bar-password hashing elsewhere, kept local like those.
+const HASH_ROUNDS = 12;
+
+/** The shortest a claimed-name password may be. Light, for a party app. */
+export const GUEST_PASSWORD_MIN = 4;
+
+// Tags the pages branch on, so they never have to read our English messages.
+// A claimed name and a wrong password are both a 401; these tell them apart.
+export const NAME_CLAIMED = "name_claimed";
+export const PASSWORD_INCORRECT = "password_incorrect";
+
+/** What a resolved sign-in carries into the session cookie. */
+export interface ResolvedGuest {
+  /** The name to remember them by. The stored spelling when a name is claimed,
+   * so favourites and history stay put whatever case they typed. */
+  name: string;
+  /** True once they've proved (or just set) a password for the name. */
+  authenticated: boolean;
+}
+
+/** Treats a blank or missing password as no password at all. */
+function supplied(password: string | undefined): string | undefined {
+  return password && password.length > 0 ? password : undefined;
+}
+
+/**
+ * Settles who a guest is before we hand them a session.
+ *
+ * - Claimed, right password    → a proven regular (their stored name).
+ * - Claimed, wrong/no password → turned away (401), so a namesake can't walk in.
+ * - Unclaimed, password given  → the name is claimed now, and they're proven.
+ * - Unclaimed, no password     → a one-time guest, signed in anonymously. Quick.
+ */
+export async function resolveGuest(
+  db: Db,
+  barId: number,
+  name: string,
+  password: string | undefined
+): Promise<ResolvedGuest> {
+  const pw = supplied(password);
+  const account = findGuestAccount(db, barId, name);
+
+  if (account) {
+    // Missing and wrong are the same refusal, but the pages need to tell a
+    // "this name is registered, enter its password" prompt from a plain
+    // "wrong password", so the two carry different tags.
+    if (!pw) throw new HttpError(401, "That name is registered here", NAME_CLAIMED);
+
+    const matches = await bcrypt.compare(pw, account.password_hash);
+    if (!matches) throw new HttpError(401, "Wrong password", PASSWORD_INCORRECT);
+
+    return { name: account.name, authenticated: true };
+  }
+
+  if (pw) {
+    if (pw.length < GUEST_PASSWORD_MIN) {
+      throw HttpError.badRequest(
+        `Password must be at least ${GUEST_PASSWORD_MIN} characters long`
+      );
+    }
+
+    const passwordHash = await bcrypt.hash(pw, HASH_ROUNDS);
+    try {
+      run(
+        db,
+        "INSERT INTO guest_accounts (bar_id, name, password_hash) VALUES (?, ?, ?)",
+        barId,
+        name,
+        passwordHash
+      );
+    } catch {
+      // Someone claimed the same name between our look-up and this insert.
+      // Treat it like any other claimed name — the password they set isn't it.
+      throw new HttpError(409, "That name was just claimed", NAME_CLAIMED);
+    }
+
+    return { name, authenticated: true };
+  }
+
+  return { name, authenticated: false };
+}
+
+/**
+ * Changes a claimed name's password. The caller has already proved they are the
+ * regular whose name this is.
+ */
+export async function changeGuestPassword(
+  db: Db,
+  barId: number,
+  name: string,
+  currentPassword: string,
+  newPassword: string
+): Promise<void> {
+  const account = findGuestAccount(db, barId, name);
+  if (!account) throw HttpError.notFound("No account for this name");
+
+  const matches = await bcrypt.compare(currentPassword, account.password_hash);
+  if (!matches) throw new HttpError(401, "Wrong password", PASSWORD_INCORRECT);
+
+  if (newPassword.length < GUEST_PASSWORD_MIN) {
+    throw HttpError.badRequest(
+      `Password must be at least ${GUEST_PASSWORD_MIN} characters long`
+    );
+  }
+
+  const passwordHash = await bcrypt.hash(newPassword, HASH_ROUNDS);
+  run(db, "UPDATE guest_accounts SET password_hash = ? WHERE id = ?", passwordHash, account.id);
+}

--- a/backend/src/auth/middleware.ts
+++ b/backend/src/auth/middleware.ts
@@ -26,6 +26,7 @@ export function attachSession(
       barId: payload.barId,
       role: payload.role,
       ...(payload.name !== undefined ? { name: payload.name } : {}),
+      ...(payload.authenticated ? { authenticated: true } : {}),
     } satisfies Session;
   }
 
@@ -61,6 +62,19 @@ export function requireGuest(res: Response): { barId: number; name: string } {
   const session = requireSession(res);
   if (session.role !== "guest" || !session.name) {
     throw HttpError.forbidden("Only a guest can do this");
+  }
+  return { barId: session.barId, name: session.name };
+}
+
+/**
+ * A regular: a guest who proved a password for their name. For the few things
+ * only a claimed name should do — changing its own password. A one-time guest,
+ * whose name nobody has claimed, is turned away.
+ */
+export function requireRegular(res: Response): { barId: number; name: string } {
+  const session = requireSession(res);
+  if (session.role !== "guest" || !session.name || session.authenticated !== true) {
+    throw HttpError.forbidden("Only a signed-in regular can do this");
   }
   return { barId: session.barId, name: session.name };
 }

--- a/backend/src/auth/session.ts
+++ b/backend/src/auth/session.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 
 import type { UserType } from "../../../shared/types.js";
-import { COOKIE_SECURE, SESSION_TTL_MS } from "../config.js";
+import { COOKIE_SECURE, GUEST_SESSION_TTL_MS, SESSION_TTL_MS } from "../config.js";
 import { decodeToken, encodeToken, readCookie } from "./tokens.js";
 
 /** Who someone is, once their cookie has been checked. */
@@ -10,6 +10,13 @@ export interface Session {
   role: UserType;
   /** A guest's name, so an order can't be placed or cancelled as someone else. */
   name?: string;
+  /** A guest who proved a password for their name — a "regular". */
+  authenticated?: boolean;
+}
+
+/** A guest's cookie outlives the bartender's single shift. */
+function ttlFor(role: UserType): number {
+  return role === "guest" ? GUEST_SESSION_TTL_MS : SESSION_TTL_MS;
 }
 
 /** The signed contents of a cookie: a session, plus when it was made and dies. */
@@ -28,10 +35,11 @@ export function signSession(session: Session, now: number = Date.now()): string 
     v: 1,
     barId: session.barId,
     role: session.role,
-    // Only carry a name when there is one — the type won't take undefined.
+    // Only carry these when they're set — the type won't take undefined.
     ...(session.name !== undefined ? { name: session.name } : {}),
+    ...(session.authenticated ? { authenticated: true } : {}),
     iat: now,
-    exp: now + SESSION_TTL_MS,
+    exp: now + ttlFor(session.role),
   };
 
   return encodeToken(payload);
@@ -48,7 +56,8 @@ function isSessionPayload(value: unknown, now: number): value is SessionPayload 
     typeof p["iat"] === "number" &&
     typeof p["exp"] === "number" &&
     p["exp"] > now &&
-    (p["name"] === undefined || typeof p["name"] === "string")
+    (p["name"] === undefined || typeof p["name"] === "string") &&
+    (p["authenticated"] === undefined || typeof p["authenticated"] === "boolean")
   );
 }
 
@@ -72,7 +81,7 @@ const COOKIE_OPTIONS = {
 export function setSessionCookie(res: Response, session: Session): void {
   res.cookie(COOKIE_NAME, signSession(session), {
     ...COOKIE_OPTIONS,
-    maxAge: SESSION_TTL_MS,
+    maxAge: ttlFor(session.role),
   });
 }
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -52,6 +52,10 @@ export const TRUST_PROXY: TrustProxy = (() => {
   return raw;
 })();
 
+// The bcrypt work factor for every password we store — bar codes, reset codes,
+// and guests' own passwords. One number so they never drift apart.
+export const HASH_ROUNDS = 12;
+
 // How long a bartender's sign-in lasts. Their screen sits on a counter all
 // night, so a whole day rather than a short idle window.
 export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -52,9 +52,15 @@ export const TRUST_PROXY: TrustProxy = (() => {
   return raw;
 })();
 
-// How long a sign-in lasts. The bartender screen sits on a counter all night,
-// so a whole day rather than a short idle window.
+// How long a bartender's sign-in lasts. Their screen sits on a counter all
+// night, so a whole day rather than a short idle window.
 export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+// A guest's sign-in lasts longer: a regular who claimed their name shouldn't
+// have to type it again across a weekend of parties. Set GUEST_SESSION_TTL_DAYS
+// to change it; the default is a month.
+export const GUEST_SESSION_TTL_MS: number =
+  (Number(process.env.GUEST_SESSION_TTL_DAYS) || 30) * 24 * 60 * 60 * 1000;
 
 // The key that signs sign-in cookies. Set SESSION_SECRET so it stays the same
 // across restarts (and across several servers). Left unset, the server keeps a

--- a/backend/src/db/migrations/2026-08-10-add-guest-accounts.sql
+++ b/backend/src/db/migrations/2026-08-10-add-guest-accounts.sql
@@ -1,0 +1,14 @@
+-- Migration: guest accounts — let a regular claim their name for a bar with a
+-- password. Favourites and past orders stay keyed by the name, so nothing that
+-- already exists moves; this only adds an optional lock on a name.
+CREATE TABLE IF NOT EXISTS guest_accounts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bar_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (bar_id) REFERENCES bars (id) ON DELETE CASCADE,
+    -- One claim per name per bar, matched without regard to case so "Ada" and
+    -- "ada" can't be claimed twice.
+    UNIQUE(bar_id, name COLLATE NOCASE)
+);

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -15,6 +15,18 @@ export interface BarRow extends Bar {
   guest_token: string | null;
 }
 
+/**
+ * A claimed guest name for a bar. A regular sets a password to make their name
+ * theirs; one-time guests never get a row here.
+ */
+export interface GuestAccountRow {
+  id: number;
+  bar_id: number;
+  name: string;
+  password_hash: string;
+  created_at: string;
+}
+
 /** The parts of a bar that are safe to send out. */
 export function publicBar(bar: BarRow): Bar {
   const {
@@ -70,6 +82,23 @@ export function findBar(db: Db, barId: number): BarRow {
   );
   if (!bar) throw HttpError.notFound("Bar not found");
   return bar;
+}
+
+/**
+ * A claimed name for a bar, matched without regard to case so it lines up with
+ * the table's uniqueness. Nothing when the name is still free.
+ */
+export function findGuestAccount(
+  db: Db,
+  barId: number,
+  name: string
+): GuestAccountRow | undefined {
+  return one<GuestAccountRow>(
+    db,
+    "SELECT * FROM guest_accounts WHERE bar_id = ? AND name = ? COLLATE NOCASE",
+    barId,
+    name
+  );
 }
 
 export function findDrink(db: Db, drinkId: number, barId: number): Drink {

--- a/backend/src/http.ts
+++ b/backend/src/http.ts
@@ -4,7 +4,12 @@ import type { NextFunction, Request, RequestHandler, Response } from "express";
 export class HttpError extends Error {
   constructor(
     readonly status: number,
-    message: string
+    message: string,
+    /**
+     * A short machine-readable tag the pages can branch on, when the same
+     * status means different things (a claimed name vs. a wrong password).
+     */
+    readonly code?: string
   ) {
     super(message);
     this.name = "HttpError";
@@ -114,7 +119,9 @@ export function errorReply(
   _next: NextFunction
 ): void {
   if (err instanceof HttpError) {
-    res.status(err.status).json({ error: err.message });
+    res
+      .status(err.status)
+      .json(err.code ? { error: err.message, code: err.code } : { error: err.message });
     return;
   }
 

--- a/backend/src/passwords/reset.ts
+++ b/backend/src/passwords/reset.ts
@@ -1,13 +1,12 @@
 import { randomInt } from "node:crypto";
 import bcrypt from "bcrypt";
 
+import { HASH_ROUNDS } from "../config.js";
 import { one, run, type Db } from "../db/queries.js";
 
 // Setting a lost password back to something known. Kept as a plain function so
 // the recovery command can use it today and an operator route could use the
 // very same thing later — neither has to know how the other shows the result.
-
-const HASH_ROUNDS = 12;
 
 // No look-alike characters (no i, l, o, 0, 1), so a code read off a screen and
 // typed on a phone doesn't trip on which letter it was.

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,12 +2,19 @@ import express, { type Router } from "express";
 import bcrypt from "bcrypt";
 
 import type { SignedIn, UserType } from "../../../shared/types.js";
-import { HttpError, requireId, requireText, route } from "../http.js";
+import {
+  HttpError,
+  optionalText,
+  requireId,
+  requireText,
+  route,
+} from "../http.js";
 import {
   clearSessionCookie,
   setSessionCookie,
 } from "../auth/session.js";
-import { currentSession } from "../auth/middleware.js";
+import { currentSession, requireRegular } from "../auth/middleware.js";
+import { changeGuestPassword, resolveGuest } from "../auth/guestAccounts.js";
 import {
   findBar,
   publicBar,
@@ -26,8 +33,18 @@ const PASSWORD_FIELD = {
  * The reply to a sign-in. The whole bar goes back, so the pages never have to
  * piece one together from loose fields and lose its settings doing it.
  */
-function signedInAs(bar: BarRow, userType: UserType): SignedIn {
-  return { success: true, userType, bar: publicBar(bar) };
+function signedInAs(
+  bar: BarRow,
+  userType: UserType,
+  authenticated = false
+): SignedIn {
+  return {
+    success: true,
+    userType,
+    bar: publicBar(bar),
+    // Only a guest can be a proven regular; the flag is noise on a bartender.
+    ...(userType === "guest" ? { authenticated } : {}),
+  };
 }
 
 export default function createAuthRoutes(db: Db): Router {
@@ -76,9 +93,27 @@ export default function createAuthRoutes(db: Db): Router {
         label: "Customer name",
       });
       const bar = await signIn(req.body, "guest");
-      setSessionCookie(res, { barId: bar.id, role: "guest", name: customerName });
 
-      res.json({ ...signedInAs(bar, "guest"), customerName });
+      // The bar's shared password got them this far; a claimed name still has to
+      // be proved with its own. An unclaimed name walks straight in.
+      const resolved = await resolveGuest(
+        db,
+        bar.id,
+        customerName,
+        optionalText(req.body, "accountPassword")
+      );
+
+      setSessionCookie(res, {
+        barId: bar.id,
+        role: "guest",
+        name: resolved.name,
+        ...(resolved.authenticated ? { authenticated: true } : {}),
+      });
+
+      res.json({
+        ...signedInAs(bar, "guest", resolved.authenticated),
+        customerName: resolved.name,
+      });
     })
   );
 
@@ -91,13 +126,30 @@ export default function createAuthRoutes(db: Db): Router {
       if (!session) throw HttpError.unauthorized("Not signed in");
 
       const bar = findBar(db, session.barId);
-      const reply = signedInAs(bar, session.role);
+      const reply = signedInAs(bar, session.role, session.authenticated === true);
 
       res.json(
         session.role === "guest" && session.name
           ? { ...reply, customerName: session.name }
           : reply
       );
+    })
+  );
+
+  // A regular changes their own name's password. requireRegular guarantees the
+  // cookie already proved this is their name, so we only need the old password.
+  router.put(
+    "/guest/password",
+    route(async (req, res) => {
+      const { barId, name } = requireRegular(res);
+      const currentPassword = requireText(req.body, "currentPassword");
+      const newPassword = requireText(req.body, "newPassword", {
+        label: "New password",
+      });
+
+      await changeGuestPassword(db, barId, name, currentPassword, newPassword);
+
+      res.json({ success: true });
     })
   );
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -27,6 +27,7 @@ import {
   listRegulars,
   renameRegular,
   resolveGuest,
+  setRegularPassword,
 } from "../auth/guestAccounts.js";
 import {
   requireBartender,
@@ -401,6 +402,22 @@ export default function createBarRoutes({
       const accountId = idParam(req, "accountId");
       const name = requireText(req.body, "name", { min: 2, label: "Name" });
       res.json(renameRegular(db, barId, accountId, name));
+    })
+  );
+
+  // Reset a regular's password. No old password asked for — the bartender is
+  // trusted, and this is the way back in for a regular who forgot theirs.
+  router.put(
+    "/:id/regulars/:accountId/password",
+    route(async (req, res) => {
+      const barId = ownBar(req, res);
+      findBar(db, barId);
+      const accountId = idParam(req, "accountId");
+      const newPassword = requireText(req.body, "newPassword", {
+        label: "Password",
+      });
+      await setRegularPassword(db, barId, accountId, newPassword);
+      res.json({ success: true });
     })
   );
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -23,7 +23,11 @@ import {
   wasSent,
 } from "../http.js";
 import { setSessionCookie } from "../auth/session.js";
-import { resolveGuest } from "../auth/guestAccounts.js";
+import {
+  listRegulars,
+  renameRegular,
+  resolveGuest,
+} from "../auth/guestAccounts.js";
 import {
   requireBartender,
   requireBartenderForBar,
@@ -373,6 +377,30 @@ export default function createBarRoutes({
       } satisfies BarQrCode;
 
       res.json(code);
+    })
+  );
+
+  // The regulars who have claimed a name at this bar. Bartender-only; the
+  // list never carries a password.
+  router.get(
+    "/:id/regulars",
+    route((req, res) => {
+      const barId = ownBar(req, res);
+      findBar(db, barId);
+      res.json(listRegulars(db, barId));
+    })
+  );
+
+  // Rename a regular, moving their favourites and past orders with them. For
+  // the bartender to fix a name or tell two same-named regulars apart.
+  router.put(
+    "/:id/regulars/:accountId",
+    route((req, res) => {
+      const barId = ownBar(req, res);
+      findBar(db, barId);
+      const accountId = idParam(req, "accountId");
+      const name = requireText(req.body, "name", { min: 2, label: "Name" });
+      res.json(renameRegular(db, barId, accountId, name));
     })
   );
 

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -23,6 +23,7 @@ import {
   wasSent,
 } from "../http.js";
 import { setSessionCookie } from "../auth/session.js";
+import { resolveGuest } from "../auth/guestAccounts.js";
 import {
   requireBartender,
   requireBartenderForBar,
@@ -377,7 +378,7 @@ export default function createBarRoutes({
 
   router.post(
     "/:id/guest-token-login",
-    route((req, res) => {
+    route(async (req, res) => {
       const barId = idParam(req, "id");
       const token = requireText(req.body, "token");
       const customerName = requireText(req.body, "customerName", {
@@ -391,16 +392,30 @@ export default function createBarRoutes({
         throw new HttpError(401, "Invalid or expired token");
       }
 
-      // The QR link gets you a session; it isn't one itself.
-      setSessionCookie(res, { barId: bar.id, role: "guest", name: customerName });
+      // The QR link gets you a session; it isn't one itself. A claimed name
+      // still has to be proved with its password before the session is set.
+      const resolved = await resolveGuest(
+        db,
+        bar.id,
+        customerName,
+        optionalText(req.body, "accountPassword")
+      );
+
+      setSessionCookie(res, {
+        barId: bar.id,
+        role: "guest",
+        name: resolved.name,
+        ...(resolved.authenticated ? { authenticated: true } : {}),
+      });
 
       res.json({
         success: true,
         barId: bar.id,
         barName: bar.name,
         language: bar.language,
-        customerName,
+        customerName: resolved.name,
         userType: "guest",
+        authenticated: resolved.authenticated,
       });
     })
   );

--- a/backend/src/routes/bars.ts
+++ b/backend/src/routes/bars.ts
@@ -12,6 +12,7 @@ import type {
   BarQrCode,
   Language,
   Order,
+  SignedIn,
 } from "../../../shared/types.js";
 import {
   HttpError,
@@ -22,6 +23,7 @@ import {
   toFlag,
   wasSent,
 } from "../http.js";
+import { HASH_ROUNDS } from "../config.js";
 import { setSessionCookie } from "../auth/session.js";
 import {
   listRegulars,
@@ -51,8 +53,6 @@ const PASSWORD_RULES = {
   bartender: { min: 4, label: "Bartender password" },
   guest: { min: 3, label: "Guest password" },
 } as const;
-
-const HASH_ROUNDS = 12;
 
 /** The bar fields that are safe to list. Never the token or the hashes. */
 const PUBLIC_COLUMNS =
@@ -453,15 +453,15 @@ export default function createBarRoutes({
         ...(resolved.authenticated ? { authenticated: true } : {}),
       });
 
+      // The same shape every other sign-in sends, so the pages read one thing:
+      // the whole bar, the name, and whether a password was proved.
       res.json({
         success: true,
-        barId: bar.id,
-        barName: bar.name,
-        language: bar.language,
-        customerName: resolved.name,
         userType: "guest",
+        bar: publicBar(bar),
+        customerName: resolved.name,
         authenticated: resolved.authenticated,
-      });
+      } satisfies SignedIn);
     })
   );
 

--- a/backend/tests/guest-accounts.test.ts
+++ b/backend/tests/guest-accounts.test.ts
@@ -321,6 +321,65 @@ describe("renaming a regular", () => {
   });
 });
 
+describe("the bartender resetting a regular's password", () => {
+  it("sets a new password without asking for the old one", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    const accountId = Number(
+      (
+        db
+          .prepare("SELECT id FROM guest_accounts WHERE bar_id = ?")
+          .get(barId) as { id: number }
+      ).id
+    );
+
+    const res = await request(app)
+      .put(`/api/bars/${barId}/regulars/${accountId}/password`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
+      .send({ newPassword: "freshone" });
+    expect(res.status).toBe(200);
+
+    // The old password no longer works; the one the bartender set does.
+    const oldPw = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    expect(oldPw.status).toBe(401);
+    const newPw = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "freshone",
+    });
+    expect(newPw.status).toBe(200);
+    expect(newPw.body.authenticated).toBe(true);
+  });
+
+  it("is the bartender's alone", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    const accountId = Number(
+      (
+        db
+          .prepare("SELECT id FROM guest_accounts WHERE bar_id = ?")
+          .get(barId) as { id: number }
+      ).id
+    );
+
+    const asGuest = await request(app)
+      .put(`/api/bars/${barId}/regulars/${accountId}/password`)
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Ada" }))
+      .send({ newPassword: "freshone" });
+    expect(asGuest.status).toBe(403);
+  });
+});
+
 describe("changing a regular's password", () => {
   it("turns away a one-time guest who never claimed a name", async () => {
     const { app, db } = makeTestApp();

--- a/backend/tests/guest-accounts.test.ts
+++ b/backend/tests/guest-accounts.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import type { Express } from "express";
+
+import {
+  makeTestApp,
+  seedBar,
+  sessionCookie,
+  cleanUpTempDirs,
+} from "./helpers.js";
+import type { Db } from "../src/db/queries.js";
+import { GUEST_SESSION_TTL_MS, SESSION_TTL_MS } from "../src/config.js";
+
+afterAll(cleanUpTempDirs);
+
+// A known QR token on a seeded bar, so the token-login door opens without
+// depending on how the original fixed token is spelled.
+function seedBarWithToken(db: Db): {
+  barId: number;
+  drinkId: number;
+  token: string;
+} {
+  const { barId, drinkId } = seedBar(db);
+  const token = "qr-token";
+  db.prepare("UPDATE bars SET guest_token = ? WHERE id = ?").run(token, barId);
+  return { barId, drinkId, token };
+}
+
+function tokenLogin(
+  app: Express,
+  barId: number,
+  token: string,
+  body: { customerName: string; accountPassword?: string }
+) {
+  return request(app)
+    .post(`/api/bars/${barId}/guest-token-login`)
+    .send({ token, ...body });
+}
+
+describe("claiming a name", () => {
+  it("lets a one-time guest in without a password and claims nothing", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+
+    const res = await tokenLogin(app, barId, token, { customerName: "Bea" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticated).toBe(false);
+    // Nobody claimed anything.
+    const account = db
+      .prepare("SELECT * FROM guest_accounts WHERE bar_id = ?")
+      .get(barId);
+    expect(account).toBeUndefined();
+  });
+
+  it("claims the name when a guest sets a password, and marks them a regular", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+
+    const res = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticated).toBe(true);
+    const account = db
+      .prepare("SELECT name FROM guest_accounts WHERE bar_id = ?")
+      .get(barId) as { name: string } | undefined;
+    expect(account?.name).toBe("Ada");
+  });
+
+  it("refuses a claimed name with no password, and says so distinctly", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const res = await tokenLogin(app, barId, token, { customerName: "Ada" });
+
+    expect(res.status).toBe(401);
+    // The pages branch on this to reveal the password field.
+    expect(res.body.code).toBe("name_claimed");
+  });
+
+  it("refuses a claimed name with the wrong password", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const res = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "guess",
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("password_incorrect");
+  });
+
+  it("lets the regular back in with the right password", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const res = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticated).toBe(true);
+  });
+
+  it("claims a name once, whatever the case, and remembers its spelling", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    // A differently-cased spelling is the same claimed name...
+    const clash = await tokenLogin(app, barId, token, { customerName: "ADA" });
+    expect(clash.status).toBe(401);
+    expect(clash.body.code).toBe("name_claimed");
+
+    // ...and signing in keeps the spelling the name was claimed with, so the
+    // one set of favourites and history stays put.
+    const back = await tokenLogin(app, barId, token, {
+      customerName: "ada",
+      accountPassword: "secret",
+    });
+    expect(back.status).toBe(200);
+    expect(back.body.customerName).toBe("Ada");
+  });
+});
+
+describe("existing guests keep what's theirs", () => {
+  it("keeps favourites reachable after the name is claimed", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, drinkId, token } = seedBarWithToken(db);
+
+    // A favourite marked as an anonymous guest named Ada, before any password.
+    const anon = sessionCookie({ barId, role: "guest", name: "Ada" });
+    const marked = await request(app)
+      .post(`/api/drinks/bar/${barId}/favourites`)
+      .set("Cookie", anon)
+      .send({ drinkId });
+    expect(marked.status).toBe(201);
+
+    // Now Ada claims her name.
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    // The favourite from before is still hers.
+    const favourites = await request(app)
+      .get(`/api/drinks/bar/${barId}/favourites/Ada`)
+      .set("Cookie", anon);
+    expect(favourites.status).toBe(200);
+    expect(favourites.body).toHaveLength(1);
+  });
+});
+
+describe("the guest cookie outlives the bartender's", () => {
+  it("gives a guest a much longer cookie than a bartender", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+
+    const res = await tokenLogin(app, barId, token, { customerName: "Bea" });
+    const cookie = res.headers["set-cookie"]?.[0] ?? "";
+
+    const maxAge = Number(/Max-Age=(\d+)/i.exec(cookie)?.[1]);
+    // Seconds, and it should be the guest length, well past the bartender day.
+    expect(maxAge).toBe(GUEST_SESSION_TTL_MS / 1000);
+    expect(maxAge).toBeGreaterThan(SESSION_TTL_MS / 1000);
+  });
+});
+
+describe("changing a regular's password", () => {
+  it("turns away a one-time guest who never claimed a name", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const res = await request(app)
+      .put("/api/auth/guest/password")
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Bea" }))
+      .send({ currentPassword: "x", newPassword: "yyyy" });
+
+    // Not authenticated → forbidden, before any password is even looked at.
+    expect(res.status).toBe(403);
+  });
+
+  it("lets a regular change their password with the right current one", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const regular = sessionCookie({
+      barId,
+      role: "guest",
+      name: "Ada",
+      authenticated: true,
+    });
+
+    const res = await request(app)
+      .put("/api/auth/guest/password")
+      .set("Cookie", regular)
+      .send({ currentPassword: "secret", newPassword: "another" });
+    expect(res.status).toBe(200);
+
+    // The old password no longer gets them in; the new one does.
+    const oldPw = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    expect(oldPw.status).toBe(401);
+    const newPw = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "another",
+    });
+    expect(newPw.status).toBe(200);
+  });
+
+  it("refuses a change when the current password is wrong", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const res = await request(app)
+      .put("/api/auth/guest/password")
+      .set(
+        "Cookie",
+        sessionCookie({ barId, role: "guest", name: "Ada", authenticated: true })
+      )
+      .send({ currentPassword: "wrong", newPassword: "another" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("password_incorrect");
+  });
+});

--- a/backend/tests/guest-accounts.test.ts
+++ b/backend/tests/guest-accounts.test.ts
@@ -186,6 +186,141 @@ describe("the guest cookie outlives the bartender's", () => {
   });
 });
 
+describe("the bartender's list of regulars", () => {
+  it("lists claimed names, and never a password", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+
+    const res = await request(app)
+      .get(`/api/bars/${barId}/regulars`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ name: "Ada" });
+    expect(JSON.stringify(res.body)).not.toMatch(/password/);
+  });
+
+  it("is the bartender's alone", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const asGuest = await request(app)
+      .get(`/api/bars/${barId}/regulars`)
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Ada" }));
+    expect(asGuest.status).toBe(403);
+
+    const noCookie = await request(app).get(`/api/bars/${barId}/regulars`);
+    expect(noCookie.status).toBe(401);
+  });
+});
+
+describe("renaming a regular", () => {
+  it("carries their favourites and past orders to the new name", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, drinkId } = seedBarWithToken(db);
+
+    // A favourite and a settled order under the bare name, then the claim.
+    db.prepare(
+      "INSERT INTO user_favourites (bar_id, customer_name, drink_id) VALUES (?, 'Ada', ?)"
+    ).run(barId, drinkId);
+    db.prepare(
+      "INSERT INTO orders (bar_id, customer_name, drink_id, drink_title, status) VALUES (?, 'Ada', ?, 'Negroni', 'processed')"
+    ).run(barId, drinkId);
+    const account = db
+      .prepare("INSERT INTO guest_accounts (bar_id, name, password_hash) VALUES (?, 'Ada', 'x')")
+      .run(barId);
+    const accountId = Number(account.lastInsertRowid);
+
+    const res = await request(app)
+      .put(`/api/bars/${barId}/regulars/${accountId}`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
+      .send({ name: "Ada Lovelace" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ name: "Ada Lovelace" });
+
+    const favNames = db
+      .prepare("SELECT DISTINCT customer_name AS n FROM user_favourites WHERE bar_id = ?")
+      .all(barId)
+      .map((r) => (r as { n: string }).n);
+    expect(favNames).toEqual(["Ada Lovelace"]);
+
+    const orderNames = db
+      .prepare("SELECT DISTINCT customer_name AS n FROM orders WHERE bar_id = ?")
+      .all(barId)
+      .map((r) => (r as { n: string }).n);
+    expect(orderNames).toEqual(["Ada Lovelace"]);
+  });
+
+  it("frees the old name and keeps the password on the new one", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    const accountId = Number(
+      (
+        db
+          .prepare("SELECT id FROM guest_accounts WHERE bar_id = ?")
+          .get(barId) as { id: number }
+      ).id
+    );
+
+    await request(app)
+      .put(`/api/bars/${barId}/regulars/${accountId}`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
+      .send({ name: "Bea" });
+
+    // The old name is free for a one-time guest again.
+    const oldName = await tokenLogin(app, barId, token, { customerName: "Ada" });
+    expect(oldName.status).toBe(200);
+    expect(oldName.body.authenticated).toBe(false);
+
+    // The new name still needs the same password.
+    const newNoPw = await tokenLogin(app, barId, token, { customerName: "Bea" });
+    expect(newNoPw.status).toBe(401);
+    const newWithPw = await tokenLogin(app, barId, token, {
+      customerName: "Bea",
+      accountPassword: "secret",
+    });
+    expect(newWithPw.status).toBe(200);
+    expect(newWithPw.body.authenticated).toBe(true);
+  });
+
+  it("won't collide with a name another regular already holds", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+    await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    await tokenLogin(app, barId, token, {
+      customerName: "Bea",
+      accountPassword: "other",
+    });
+    const adaId = Number(
+      (
+        db
+          .prepare("SELECT id FROM guest_accounts WHERE name = 'Ada' AND bar_id = ?")
+          .get(barId) as { id: number }
+      ).id
+    );
+
+    const res = await request(app)
+      .put(`/api/bars/${barId}/regulars/${adaId}`)
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
+      .send({ name: "Bea" });
+
+    expect(res.status).toBe(409);
+  });
+});
+
 describe("changing a regular's password", () => {
   it("turns away a one-time guest who never claimed a name", async () => {
     const { app, db } = makeTestApp();

--- a/backend/tests/helpers.ts
+++ b/backend/tests/helpers.ts
@@ -93,6 +93,7 @@ export function sessionCookie(session: {
   barId: number;
   role: UserType;
   name?: string;
+  authenticated?: boolean;
 }): string {
   return `session=${signSession(session)}`;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import BartenderShell from "./components/bartender/BartenderShell";
 import OrdersTab from "./components/OrdersTab";
 import MenuTab from "./components/MenuTab";
 import CategoriesTab from "./components/CategoriesTab";
+import RegularsTab from "./components/bartender/RegularsTab";
 import AnalyticsTab from "./components/AnalyticsTab";
 import SettingsTab from "./components/SettingsTab";
 import CustomerInterface from "./components/CustomerInterface";
@@ -86,6 +87,7 @@ const AppContent: React.FC = () => {
           {/* Adding and editing a drink are screens, not a dialog over one. */}
           <Route path="menu/:drinkId" element={<DrinkForm />} />
           <Route path="categories" element={<CategoriesTab />} />
+          <Route path="regulars" element={<RegularsTab />} />
           <Route path="analytics" element={<AnalyticsTab />} />
           <Route path="settings" element={<SettingsTab />} />
         </Route>

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -2,8 +2,9 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Eye, EyeOff, LogIn } from "lucide-react";
 import { useApp } from "../hooks/useApp";
-import type { Bar } from "../types";
+import type { Bar, SignedIn } from "../types";
 import { useTranslation } from "../utils/translations";
+import { ApiError } from "../utils/api";
 import { rememberMe } from "../hooks/useSessionManager";
 import ToggleRow from "./ToggleRow";
 
@@ -31,6 +32,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
     setLoginForm,
     setShowPassword,
     setCustomerName,
+    setAuthenticated,
     setLoading,
     setError,
     apiCall,
@@ -52,6 +54,10 @@ const LoginForm: React.FC<LoginFormProps> = ({
 
   // Kept on by default: most people at a party are on their own phone.
   const [remember, setRemember] = useState(true);
+  // The optional per-name password, kept apart from the bar's shared one above.
+  const [accountPassword, setAccountPassword] = useState("");
+  const [claiming, setClaiming] = useState(false);
+  const [nameClaimed, setNameClaimed] = useState(false);
 
   const handleLogin = async () => {
     if (!loginForm.password) {
@@ -72,30 +78,47 @@ const LoginForm: React.FC<LoginFormProps> = ({
     setLoading(true);
     setError(null);
 
+    const accountPw = accountPassword.trim();
+
     try {
       const endpoint =
         userType === "bartender" ? "/auth/bartender" : "/auth/guest";
       const body = {
         barId,
         password: loginForm.password,
-        // Guests give their name; the bartender does not.
-        ...(userType === "guest" && { customerName: loginForm.name }),
+        // Guests give their name, and optionally a password to claim or prove
+        // it; the bartender does neither.
+        ...(userType === "guest" && {
+          customerName: loginForm.name,
+          ...(accountPw ? { accountPassword: accountPw } : {}),
+        }),
       };
 
-      await apiCall(endpoint, {
+      const response = await apiCall<SignedIn>(endpoint, {
         method: "POST",
         body: JSON.stringify(body),
       });
 
       // Set customer name in context for guests
       if (userType === "guest") {
-        setCustomerName(loginForm.name);
+        setCustomerName(response.customerName ?? loginForm.name);
+        setAuthenticated(response.authenticated === true);
         rememberMe(remember);
       }
 
       navigate(userType === "bartender" ? "/bartender" : "/customer");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Login failed");
+      if (err instanceof ApiError && err.code === "name_claimed") {
+        setNameClaimed(true);
+        setClaiming(false);
+        setError(null);
+      } else if (err instanceof ApiError && err.code === "password_incorrect") {
+        // A wrong bar password and a wrong name password are both a 401; only
+        // the name password carries this code, so it's unambiguous here.
+        setError(t("wrongPassword"));
+      } else {
+        setError(err instanceof Error ? err.message : "Login failed");
+      }
     } finally {
       setLoading(false);
     }
@@ -104,6 +127,9 @@ const LoginForm: React.FC<LoginFormProps> = ({
   const resetUserType = () => {
     setUserType(null);
     setLoginForm({ password: "", name: "" });
+    setAccountPassword("");
+    setClaiming(false);
+    setNameClaimed(false);
   };
 
   return (
@@ -189,6 +215,34 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                 onKeyPress={(e) => e.key === "Enter" && handleLogin()}
               />
+
+              {/* A claimed name has to be proved with its password. */}
+              {nameClaimed && (
+                <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
+              )}
+
+              {/* Otherwise, an unobtrusive way to make this name yours. */}
+              {!nameClaimed && (
+                <ToggleRow
+                  on={claiming}
+                  onChange={setClaiming}
+                  title={t("setPassword")}
+                  help={t("setPasswordHelp")}
+                />
+              )}
+
+              {(nameClaimed || claiming) && (
+                <input
+                  type="password"
+                  placeholder={
+                    nameClaimed ? t("yourPassword") : t("setAPassword")
+                  }
+                  value={accountPassword}
+                  onChange={(e) => setAccountPassword(e.target.value)}
+                  className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+                  onKeyPress={(e) => e.key === "Enter" && handleLogin()}
+                />
+              )}
 
               <ToggleRow
                 on={remember}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -209,9 +209,15 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 type="text"
                 placeholder={t("enterName")}
                 value={loginForm.name}
-                onChange={(e) =>
-                  setLoginForm((prev) => ({ ...prev, name: e.target.value }))
-                }
+                onChange={(e) => {
+                  setLoginForm((prev) => ({ ...prev, name: e.target.value }));
+                  // A different name is a different question — drop the "that
+                  // name is registered" prompt tied to the old one.
+                  if (nameClaimed) {
+                    setNameClaimed(false);
+                    setError(null);
+                  }
+                }}
                 className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                 onKeyPress={(e) => e.key === "Enter" && handleLogin()}
               />

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -2,9 +2,9 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Eye, EyeOff, LogIn } from "lucide-react";
 import { useApp } from "../hooks/useApp";
+import { useGuestClaim } from "../hooks/useGuestClaim";
 import type { Bar, SignedIn } from "../types";
 import { useTranslation } from "../utils/translations";
-import { ApiError } from "../utils/api";
 import { rememberMe } from "../hooks/useSessionManager";
 import ToggleRow from "./ToggleRow";
 
@@ -40,6 +40,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
 
   const navigate = useNavigate();
   const t = useTranslation(language);
+  const claim = useGuestClaim();
 
   // Use the provided bar or the current bar from context
   const targetBar = bar || currentBar;
@@ -54,10 +55,6 @@ const LoginForm: React.FC<LoginFormProps> = ({
 
   // Kept on by default: most people at a party are on their own phone.
   const [remember, setRemember] = useState(true);
-  // The optional per-name password, kept apart from the bar's shared one above.
-  const [accountPassword, setAccountPassword] = useState("");
-  const [claiming, setClaiming] = useState(false);
-  const [nameClaimed, setNameClaimed] = useState(false);
 
   const handleLogin = async () => {
     if (!loginForm.password) {
@@ -78,8 +75,6 @@ const LoginForm: React.FC<LoginFormProps> = ({
     setLoading(true);
     setError(null);
 
-    const accountPw = accountPassword.trim();
-
     try {
       const endpoint =
         userType === "bartender" ? "/auth/bartender" : "/auth/guest";
@@ -90,7 +85,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
         // it; the bartender does neither.
         ...(userType === "guest" && {
           customerName: loginForm.name,
-          ...(accountPw ? { accountPassword: accountPw } : {}),
+          ...(claim.password ? { accountPassword: claim.password } : {}),
         }),
       };
 
@@ -108,17 +103,10 @@ const LoginForm: React.FC<LoginFormProps> = ({
 
       navigate(userType === "bartender" ? "/bartender" : "/customer");
     } catch (err) {
-      if (err instanceof ApiError && err.code === "name_claimed") {
-        setNameClaimed(true);
-        setClaiming(false);
-        setError(null);
-      } else if (err instanceof ApiError && err.code === "password_incorrect") {
-        // A wrong bar password and a wrong name password are both a 401; only
-        // the name password carries this code, so it's unambiguous here.
-        setError(t("wrongPassword"));
-      } else {
-        setError(err instanceof Error ? err.message : "Login failed");
-      }
+      // A claimed name reveals the password field; a wrong one says so. A wrong
+      // bar password and a wrong name password are both a 401, but only the
+      // name password carries a code, so classify tells them apart.
+      setError(claim.classify(err, "Login failed"));
     } finally {
       setLoading(false);
     }
@@ -127,9 +115,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
   const resetUserType = () => {
     setUserType(null);
     setLoginForm({ password: "", name: "" });
-    setAccountPassword("");
-    setClaiming(false);
-    setNameClaimed(false);
+    claim.reset();
   };
 
   return (
@@ -211,40 +197,36 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 value={loginForm.name}
                 onChange={(e) => {
                   setLoginForm((prev) => ({ ...prev, name: e.target.value }));
-                  // A different name is a different question — drop the "that
-                  // name is registered" prompt tied to the old one.
-                  if (nameClaimed) {
-                    setNameClaimed(false);
-                    setError(null);
-                  }
+                  if (claim.nameClaimed) setError(null);
+                  claim.onNameChange();
                 }}
                 className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                 onKeyPress={(e) => e.key === "Enter" && handleLogin()}
               />
 
               {/* A claimed name has to be proved with its password. */}
-              {nameClaimed && (
+              {claim.nameClaimed && (
                 <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
               )}
 
               {/* Otherwise, an unobtrusive way to make this name yours. */}
-              {!nameClaimed && (
+              {!claim.nameClaimed && (
                 <ToggleRow
-                  on={claiming}
-                  onChange={setClaiming}
+                  on={claim.claiming}
+                  onChange={claim.setClaiming}
                   title={t("setPassword")}
                   help={t("setPasswordHelp")}
                 />
               )}
 
-              {(nameClaimed || claiming) && (
+              {claim.passwordVisible && (
                 <input
                   type="password"
                   placeholder={
-                    nameClaimed ? t("yourPassword") : t("setAPassword")
+                    claim.nameClaimed ? t("yourPassword") : t("setAPassword")
                   }
-                  value={accountPassword}
-                  onChange={(e) => setAccountPassword(e.target.value)}
+                  value={claim.accountPassword}
+                  onChange={(e) => claim.setAccountPassword(e.target.value)}
                   className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                   onKeyPress={(e) => e.key === "Enter" && handleLogin()}
                 />

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -214,7 +214,15 @@ const QRRedirect: React.FC = () => {
                 type="text"
                 placeholder={t("yourName")}
                 value={guestName}
-                onChange={(e) => setGuestName(e.target.value)}
+                onChange={(e) => {
+                  setGuestName(e.target.value);
+                  // A different name is a different question — drop the "that
+                  // name is registered" prompt tied to the old one.
+                  if (nameClaimed) {
+                    setNameClaimed(false);
+                    setError(null);
+                  }
+                }}
                 className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                 onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
                 autoFocus

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useApp } from "../hooks/useApp";
 import type { Bar, SignedIn } from "../types";
 import { useTranslation } from "../utils/translations";
+import { ApiError } from "../utils/api";
 import LoginForm from "./LoginForm";
 import { ACTIVITY_KEY, rememberMe } from "../hooks/useSessionManager";
 import ToggleRow from "./ToggleRow";
@@ -10,8 +11,15 @@ import ToggleRow from "./ToggleRow";
 const QRRedirect: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { language, setCurrentBar, setLanguage, setCustomerName, setUserType, apiCall } =
-    useApp();
+  const {
+    language,
+    setCurrentBar,
+    setLanguage,
+    setCustomerName,
+    setUserType,
+    setAuthenticated,
+    apiCall,
+  } = useApp();
   const t = useTranslation(language);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,6 +28,13 @@ const QRRedirect: React.FC = () => {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   // Kept on by default: someone scanning a code is on their own phone.
   const [remember, setRemember] = useState(true);
+  // The optional password for claiming or proving a name.
+  const [accountPassword, setAccountPassword] = useState("");
+  // On when the guest wants to make this name theirs (set a password).
+  const [claiming, setClaiming] = useState(false);
+  // On once the server says the name is already claimed, so we ask for its
+  // password rather than offering to set one.
+  const [nameClaimed, setNameClaimed] = useState(false);
   const hasFetched = useRef(false);
 
   useEffect(() => {
@@ -82,23 +97,33 @@ const QRRedirect: React.FC = () => {
     setIsLoggingIn(true);
     setError(null);
 
+    // Only send a password when there is one to send: proving a claimed name,
+    // or claiming an unclaimed one.
+    const password = accountPassword.trim();
+
     try {
       const response = await apiCall<SignedIn>(
         `/bars/${id}/guest-token-login`,
         {
           method: "POST",
-          body: JSON.stringify({ token, customerName: guestName.trim() }),
+          body: JSON.stringify({
+            token,
+            customerName: guestName.trim(),
+            ...(password ? { accountPassword: password } : {}),
+          }),
         }
       );
 
-      // Update app context with authentication info
-      setCustomerName(guestName.trim());
+      // Update app context with authentication info. The server hands back the
+      // stored spelling of a claimed name, so use that when it does.
+      setCustomerName(response.customerName ?? guestName.trim());
+      setAuthenticated(response.authenticated === true);
       setUserType("guest");
-      
+
       // Update session activity timestamp
       localStorage.setItem(ACTIVITY_KEY, Date.now().toString());
       rememberMe(remember);
-      
+
       // The current bar should already be set from the earlier fetchBarInfo call,
       // but let's make sure it has the latest info
       if (response.bar) {
@@ -109,7 +134,16 @@ const QRRedirect: React.FC = () => {
       // Navigate to customer interface
       navigate("/customer");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to login");
+      // A claimed name asks for its password; the wrong one says so plainly.
+      if (err instanceof ApiError && err.code === "name_claimed") {
+        setNameClaimed(true);
+        setClaiming(false);
+        setError(null);
+      } else if (err instanceof ApiError && err.code === "password_incorrect") {
+        setError(t("wrongPassword"));
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to login");
+      }
     } finally {
       setIsLoggingIn(false);
     }
@@ -185,6 +219,33 @@ const QRRedirect: React.FC = () => {
                 onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
                 autoFocus
               />
+
+              {/* A claimed name has to be proved with its password. */}
+              {nameClaimed && (
+                <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
+              )}
+
+              {/* Otherwise, an unobtrusive way to make this name yours. */}
+              {!nameClaimed && (
+                <ToggleRow
+                  on={claiming}
+                  onChange={setClaiming}
+                  title={t("setPassword")}
+                  help={t("setPasswordHelp")}
+                />
+              )}
+
+              {(nameClaimed || claiming) && (
+                <input
+                  type="password"
+                  placeholder={nameClaimed ? t("yourPassword") : t("setAPassword")}
+                  value={accountPassword}
+                  onChange={(e) => setAccountPassword(e.target.value)}
+                  className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+                  onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
+                  autoFocus={nameClaimed}
+                />
+              )}
 
               <ToggleRow
                 on={remember}

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useApp } from "../hooks/useApp";
+import { useGuestClaim } from "../hooks/useGuestClaim";
 import type { Bar, SignedIn } from "../types";
 import { useTranslation } from "../utils/translations";
-import { ApiError } from "../utils/api";
 import LoginForm from "./LoginForm";
 import { ACTIVITY_KEY, rememberMe } from "../hooks/useSessionManager";
 import ToggleRow from "./ToggleRow";
@@ -21,6 +21,7 @@ const QRRedirect: React.FC = () => {
     apiCall,
   } = useApp();
   const t = useTranslation(language);
+  const claim = useGuestClaim();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [hasToken, setHasToken] = useState(false);
@@ -28,13 +29,6 @@ const QRRedirect: React.FC = () => {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   // Kept on by default: someone scanning a code is on their own phone.
   const [remember, setRemember] = useState(true);
-  // The optional password for claiming or proving a name.
-  const [accountPassword, setAccountPassword] = useState("");
-  // On when the guest wants to make this name theirs (set a password).
-  const [claiming, setClaiming] = useState(false);
-  // On once the server says the name is already claimed, so we ask for its
-  // password rather than offering to set one.
-  const [nameClaimed, setNameClaimed] = useState(false);
   const hasFetched = useRef(false);
 
   useEffect(() => {
@@ -97,10 +91,6 @@ const QRRedirect: React.FC = () => {
     setIsLoggingIn(true);
     setError(null);
 
-    // Only send a password when there is one to send: proving a claimed name,
-    // or claiming an unclaimed one.
-    const password = accountPassword.trim();
-
     try {
       const response = await apiCall<SignedIn>(
         `/bars/${id}/guest-token-login`,
@@ -109,7 +99,8 @@ const QRRedirect: React.FC = () => {
           body: JSON.stringify({
             token,
             customerName: guestName.trim(),
-            ...(password ? { accountPassword: password } : {}),
+            // Only when there is one: proving a claimed name, or claiming a new.
+            ...(claim.password ? { accountPassword: claim.password } : {}),
           }),
         }
       );
@@ -134,16 +125,8 @@ const QRRedirect: React.FC = () => {
       // Navigate to customer interface
       navigate("/customer");
     } catch (err) {
-      // A claimed name asks for its password; the wrong one says so plainly.
-      if (err instanceof ApiError && err.code === "name_claimed") {
-        setNameClaimed(true);
-        setClaiming(false);
-        setError(null);
-      } else if (err instanceof ApiError && err.code === "password_incorrect") {
-        setError(t("wrongPassword"));
-      } else {
-        setError(err instanceof Error ? err.message : "Failed to login");
-      }
+      // A claimed name reveals the password field; anything else is a message.
+      setError(claim.classify(err, "Failed to login"));
     } finally {
       setIsLoggingIn(false);
     }
@@ -216,12 +199,8 @@ const QRRedirect: React.FC = () => {
                 value={guestName}
                 onChange={(e) => {
                   setGuestName(e.target.value);
-                  // A different name is a different question — drop the "that
-                  // name is registered" prompt tied to the old one.
-                  if (nameClaimed) {
-                    setNameClaimed(false);
-                    setError(null);
-                  }
+                  if (claim.nameClaimed) setError(null);
+                  claim.onNameChange();
                 }}
                 className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                 onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
@@ -229,29 +208,31 @@ const QRRedirect: React.FC = () => {
               />
 
               {/* A claimed name has to be proved with its password. */}
-              {nameClaimed && (
+              {claim.nameClaimed && (
                 <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
               )}
 
               {/* Otherwise, an unobtrusive way to make this name yours. */}
-              {!nameClaimed && (
+              {!claim.nameClaimed && (
                 <ToggleRow
-                  on={claiming}
-                  onChange={setClaiming}
+                  on={claim.claiming}
+                  onChange={claim.setClaiming}
                   title={t("setPassword")}
                   help={t("setPasswordHelp")}
                 />
               )}
 
-              {(nameClaimed || claiming) && (
+              {claim.passwordVisible && (
                 <input
                   type="password"
-                  placeholder={nameClaimed ? t("yourPassword") : t("setAPassword")}
-                  value={accountPassword}
-                  onChange={(e) => setAccountPassword(e.target.value)}
+                  placeholder={
+                    claim.nameClaimed ? t("yourPassword") : t("setAPassword")
+                  }
+                  value={claim.accountPassword}
+                  onChange={(e) => claim.setAccountPassword(e.target.value)}
                   className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
                   onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
-                  autoFocus={nameClaimed}
+                  autoFocus={claim.nameClaimed}
                 />
               )}
 

--- a/frontend/src/components/bartender/BartenderShell.tsx
+++ b/frontend/src/components/bartender/BartenderShell.tsx
@@ -7,6 +7,7 @@ import {
   LogOut,
   QrCode,
   Settings,
+  Users,
 } from "lucide-react";
 import { useApp } from "../../hooks/useApp";
 import type { Analytics, BarQrCode, Drink, Order } from "../../types";
@@ -23,6 +24,7 @@ const PENDING = ["new", "accepted", "ready"];
 const SETUP = [
   { to: "menu", label: "drinkMenu", Icon: List },
   { to: "categories", label: "categories", Icon: Grid2x2 },
+  { to: "regulars", label: "regulars", Icon: Users },
   { to: "analytics", label: "analytics", Icon: BarChart3 },
   { to: "settings", label: "settings", Icon: Settings },
 ] as const;

--- a/frontend/src/components/bartender/RegularsTab.tsx
+++ b/frontend/src/components/bartender/RegularsTab.tsx
@@ -1,0 +1,159 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useApp } from "../../hooks/useApp";
+import type { Regular } from "../../types";
+import { useTranslation } from "../../utils/translations";
+import { ApiError } from "../../utils/api";
+
+const INPUT =
+  "h-12 px-3.5 rounded-md border border-border bg-surface-raised text-body focus:outline-none focus:border-border-strong focus:shadow-focus";
+
+/** The regulars who have claimed a name at this bar, with a way to rename one. */
+const RegularsTab: React.FC = () => {
+  const { currentBar, language, apiCall } = useApp();
+  const t = useTranslation(language);
+  const barId = currentBar?.id;
+
+  const [regulars, setRegulars] = useState<Regular[]>([]);
+  const [loading, setLoading] = useState(true);
+  // The regular being renamed, and the name being typed for them.
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!barId) return;
+    setLoading(true);
+    try {
+      setRegulars(await apiCall<Regular[]>(`/bars/${barId}/regulars`));
+    } catch (err) {
+      console.error("Could not load the regulars:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [barId, apiCall]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const startRename = (regular: Regular) => {
+    setEditingId(regular.id);
+    setDraft(regular.name);
+    setError(null);
+  };
+
+  const cancel = () => {
+    setEditingId(null);
+    setDraft("");
+    setError(null);
+  };
+
+  const save = async (regular: Regular) => {
+    const name = draft.trim();
+    if (name.length < 2 || name === regular.name || !barId) return;
+
+    setBusy(true);
+    setError(null);
+    try {
+      await apiCall(`/bars/${barId}/regulars/${regular.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ name }),
+      });
+      cancel();
+      await refresh();
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.status === 409
+          ? t("nameTaken")
+          : err instanceof Error
+            ? err.message
+            : t("nameTaken")
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="max-w-160">
+      <div className="bg-surface border border-border rounded-md overflow-hidden">
+        <div className="px-5 py-4 border-b border-border">
+          <h2 className="text-heading">{t("regulars")}</h2>
+          <p className="text-body text-text-muted mt-1">{t("regularsIntro")}</p>
+        </div>
+
+        <div className="px-5 py-4.5 flex flex-col gap-2.5">
+          {loading ? (
+            <p className="text-body text-text-muted">{t("loading")}</p>
+          ) : regulars.length === 0 ? (
+            <p className="text-body text-text-muted">{t("noRegulars")}</p>
+          ) : (
+            regulars.map((regular) => (
+              <div
+                key={regular.id}
+                className="flex items-center gap-3 p-3 rounded-md border border-border"
+              >
+                {editingId === regular.id ? (
+                  <>
+                    <input
+                      type="text"
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      className={`${INPUT} flex-1 min-w-0`}
+                      minLength={2}
+                      autoFocus
+                      onKeyDown={(e) => e.key === "Enter" && save(regular)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => save(regular)}
+                      disabled={
+                        busy ||
+                        draft.trim().length < 2 ||
+                        draft.trim() === regular.name
+                      }
+                      className="h-12 px-3.5 shrink-0 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                    >
+                      {t("rename")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={cancel}
+                      className="h-12 px-3.5 shrink-0 rounded-md border border-border text-label text-text-muted transition-colors hover:text-text cursor-pointer"
+                    >
+                      {t("cancel")}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="flex-1 min-w-0 flex flex-col gap-0.5">
+                      <span className="font-bold text-[1.0625rem] leading-tight tracking-tight truncate">
+                        {regular.name}
+                      </span>
+                      <span className="text-body text-text-muted truncate">
+                        {t("regularSince")}{" "}
+                        {new Date(regular.created_at).toLocaleDateString()}
+                      </span>
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => startRename(regular)}
+                      className="h-12 px-3.5 shrink-0 rounded-md border border-border-strong text-label transition-colors hover:bg-surface-sunken cursor-pointer"
+                    >
+                      {t("rename")}
+                    </button>
+                  </>
+                )}
+              </div>
+            ))
+          )}
+
+          {error && <p className="text-body text-danger">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RegularsTab;

--- a/frontend/src/components/bartender/RegularsTab.tsx
+++ b/frontend/src/components/bartender/RegularsTab.tsx
@@ -7,7 +7,11 @@ import { ApiError } from "../../utils/api";
 const INPUT =
   "h-12 px-3.5 rounded-md border border-border bg-surface-raised text-body focus:outline-none focus:border-border-strong focus:shadow-focus";
 
-/** The regulars who have claimed a name at this bar, with a way to rename one. */
+/** The row being edited, and which of its two actions is open. */
+type Edit = { id: number; mode: "rename" | "password"; value: string };
+
+/** The regulars who have claimed a name at this bar, with a way to rename one
+ * or reset their password. */
 const RegularsTab: React.FC = () => {
   const { currentBar, language, apiCall } = useApp();
   const t = useTranslation(language);
@@ -15,11 +19,11 @@ const RegularsTab: React.FC = () => {
 
   const [regulars, setRegulars] = useState<Regular[]>([]);
   const [loading, setLoading] = useState(true);
-  // The regular being renamed, and the name being typed for them.
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [draft, setDraft] = useState("");
+  const [edit, setEdit] = useState<Edit | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A quiet confirmation after a password reset, shown against its row.
+  const [doneId, setDoneId] = useState<number | null>(null);
 
   const refresh = useCallback(async () => {
     if (!barId) return;
@@ -37,31 +41,45 @@ const RegularsTab: React.FC = () => {
     refresh();
   }, [refresh]);
 
-  const startRename = (regular: Regular) => {
-    setEditingId(regular.id);
-    setDraft(regular.name);
+  const open = (regular: Regular, mode: Edit["mode"]) => {
+    setEdit({ id: regular.id, mode, value: mode === "rename" ? regular.name : "" });
     setError(null);
+    setDoneId(null);
   };
 
   const cancel = () => {
-    setEditingId(null);
-    setDraft("");
+    setEdit(null);
     setError(null);
   };
 
   const save = async (regular: Regular) => {
-    const name = draft.trim();
-    if (name.length < 2 || name === regular.name || !barId) return;
+    if (!edit || !barId) return;
+    const value = edit.value.trim();
+
+    if (edit.mode === "rename") {
+      if (value.length < 2 || value === regular.name) return;
+    } else if (value.length < 4) {
+      return;
+    }
 
     setBusy(true);
     setError(null);
     try {
-      await apiCall(`/bars/${barId}/regulars/${regular.id}`, {
-        method: "PUT",
-        body: JSON.stringify({ name }),
-      });
-      cancel();
-      await refresh();
+      if (edit.mode === "rename") {
+        await apiCall(`/bars/${barId}/regulars/${regular.id}`, {
+          method: "PUT",
+          body: JSON.stringify({ name: value }),
+        });
+        cancel();
+        await refresh();
+      } else {
+        await apiCall(`/bars/${barId}/regulars/${regular.id}/password`, {
+          method: "PUT",
+          body: JSON.stringify({ newPassword: value }),
+        });
+        cancel();
+        setDoneId(regular.id);
+      }
     } catch (err) {
       setError(
         err instanceof ApiError && err.status === 409
@@ -74,6 +92,8 @@ const RegularsTab: React.FC = () => {
       setBusy(false);
     }
   };
+
+  const editing = (regular: Regular) => edit?.id === regular.id;
 
   return (
     <div className="max-w-160">
@@ -92,58 +112,81 @@ const RegularsTab: React.FC = () => {
             regulars.map((regular) => (
               <div
                 key={regular.id}
-                className="flex items-center gap-3 p-3 rounded-md border border-border"
+                className="p-3 rounded-md border border-border flex flex-col gap-2"
               >
-                {editingId === regular.id ? (
-                  <>
-                    <input
-                      type="text"
-                      value={draft}
-                      onChange={(e) => setDraft(e.target.value)}
-                      className={`${INPUT} flex-1 min-w-0`}
-                      minLength={2}
-                      autoFocus
-                      onKeyDown={(e) => e.key === "Enter" && save(regular)}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => save(regular)}
-                      disabled={
-                        busy ||
-                        draft.trim().length < 2 ||
-                        draft.trim() === regular.name
-                      }
-                      className="h-12 px-3.5 shrink-0 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                    >
-                      {t("rename")}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={cancel}
-                      className="h-12 px-3.5 shrink-0 rounded-md border border-border text-label text-text-muted transition-colors hover:text-text cursor-pointer"
-                    >
-                      {t("cancel")}
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <span className="flex-1 min-w-0 flex flex-col gap-0.5">
-                      <span className="font-bold text-[1.0625rem] leading-tight tracking-tight truncate">
-                        {regular.name}
+                <div className="flex items-center gap-3">
+                  {editing(regular) ? (
+                    <>
+                      <input
+                        type={edit?.mode === "password" ? "password" : "text"}
+                        value={edit?.value ?? ""}
+                        placeholder={
+                          edit?.mode === "password" ? t("newPassword") : undefined
+                        }
+                        onChange={(e) =>
+                          setEdit((prev) =>
+                            prev ? { ...prev, value: e.target.value } : prev
+                          )
+                        }
+                        className={`${INPUT} flex-1 min-w-0`}
+                        autoFocus
+                        onKeyDown={(e) => e.key === "Enter" && save(regular)}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => save(regular)}
+                        disabled={busy || edit?.value.trim().length === 0}
+                        className="h-12 px-3.5 shrink-0 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                      >
+                        {edit?.mode === "password"
+                          ? t("setGuestPassword")
+                          : t("rename")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancel}
+                        className="h-12 px-3.5 shrink-0 rounded-md border border-border text-label text-text-muted transition-colors hover:text-text cursor-pointer"
+                      >
+                        {t("cancel")}
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <span className="flex-1 min-w-0 flex flex-col gap-0.5">
+                        <span className="font-bold text-[1.0625rem] leading-tight tracking-tight truncate">
+                          {regular.name}
+                        </span>
+                        <span className="text-body text-text-muted truncate">
+                          {doneId === regular.id
+                            ? t("guestPasswordSet")
+                            : `${t("regularSince")} ${new Date(
+                                regular.created_at
+                              ).toLocaleDateString()}`}
+                        </span>
                       </span>
-                      <span className="text-body text-text-muted truncate">
-                        {t("regularSince")}{" "}
-                        {new Date(regular.created_at).toLocaleDateString()}
-                      </span>
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => startRename(regular)}
-                      className="h-12 px-3.5 shrink-0 rounded-md border border-border-strong text-label transition-colors hover:bg-surface-sunken cursor-pointer"
-                    >
-                      {t("rename")}
-                    </button>
-                  </>
+                      <button
+                        type="button"
+                        onClick={() => open(regular, "rename")}
+                        className="h-12 px-3.5 shrink-0 rounded-md border border-border-strong text-label transition-colors hover:bg-surface-sunken cursor-pointer"
+                      >
+                        {t("rename")}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => open(regular, "password")}
+                        className="h-12 px-3.5 shrink-0 rounded-md border border-border-strong text-label transition-colors hover:bg-surface-sunken cursor-pointer"
+                      >
+                        {t("setGuestPassword")}
+                      </button>
+                    </>
+                  )}
+                </div>
+
+                {/* Why to reset it, shown only while setting one. */}
+                {editing(regular) && edit?.mode === "password" && (
+                  <p className="text-body text-text-muted">
+                    {t("setGuestPasswordHelp")}
+                  </p>
                 )}
               </div>
             ))

--- a/frontend/src/components/bartender/RegularsTab.tsx
+++ b/frontend/src/components/bartender/RegularsTab.tsx
@@ -7,6 +7,10 @@ import { ApiError } from "../../utils/api";
 const INPUT =
   "h-12 px-3.5 rounded-md border border-border bg-surface-raised text-body focus:outline-none focus:border-border-strong focus:shadow-focus";
 
+// Mirrors the server's minimum, so the button doesn't invite a password the
+// server will only reject.
+const PASSWORD_MIN = 4;
+
 /** The row being edited, and which of its two actions is open. */
 type Edit = { id: number; mode: "rename" | "password"; value: string };
 
@@ -52,15 +56,18 @@ const RegularsTab: React.FC = () => {
     setError(null);
   };
 
-  const save = async (regular: Regular) => {
-    if (!edit || !barId) return;
+  // What makes a save worth sending: a real new name, or a long-enough password.
+  const canSave = (regular: Regular): boolean => {
+    if (!edit) return false;
     const value = edit.value.trim();
+    return edit.mode === "rename"
+      ? value.length >= 2 && value !== regular.name
+      : value.length >= PASSWORD_MIN;
+  };
 
-    if (edit.mode === "rename") {
-      if (value.length < 2 || value === regular.name) return;
-    } else if (value.length < 4) {
-      return;
-    }
+  const save = async (regular: Regular) => {
+    if (!edit || !barId || !canSave(regular)) return;
+    const value = edit.value.trim();
 
     setBusy(true);
     setError(null);
@@ -135,7 +142,7 @@ const RegularsTab: React.FC = () => {
                       <button
                         type="button"
                         onClick={() => save(regular)}
-                        disabled={busy || edit?.value.trim().length === 0}
+                        disabled={busy || !canSave(regular)}
                         className="h-12 px-3.5 shrink-0 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
                       >
                         {edit?.mode === "password"

--- a/frontend/src/components/customer/ChangePasswordSection.tsx
+++ b/frontend/src/components/customer/ChangePasswordSection.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { useApp } from "../../hooks/useApp";
+import { useTranslation } from "../../utils/translations";
+import { ApiError } from "../../utils/api";
+
+/**
+ * Lets a regular change the password on their name. Shows nothing for a
+ * one-time guest, whose name nobody has claimed, so the account controls only
+ * appear to someone who has an account.
+ */
+const ChangePasswordSection: React.FC = () => {
+  const { authenticated, language, apiCall } = useApp();
+  const t = useTranslation(language);
+
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  if (!authenticated) return null;
+
+  const submit = async () => {
+    if (!current.trim() || !next.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiCall("/auth/guest/password", {
+        method: "PUT",
+        body: JSON.stringify({
+          currentPassword: current,
+          newPassword: next.trim(),
+        }),
+      });
+      setDone(true);
+      setOpen(false);
+      setCurrent("");
+      setNext("");
+    } catch (err) {
+      setError(
+        err instanceof ApiError && err.code === "password_incorrect"
+          ? t("wrongPassword")
+          : err instanceof Error
+            ? err.message
+            : t("wrongPassword")
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <div className="flex flex-col items-start gap-1.5">
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(true);
+            setDone(false);
+          }}
+          className="h-12 px-3.5 rounded-md border border-border text-label text-text-muted transition-colors duration-(--duration-instant) hover:text-text cursor-pointer"
+        >
+          {t("changePassword")}
+        </button>
+        {done && <p className="text-body text-text-muted">{t("passwordChanged")}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full flex flex-col gap-2">
+      <input
+        type="password"
+        placeholder={t("currentPassword")}
+        value={current}
+        onChange={(e) => setCurrent(e.target.value)}
+        className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+      />
+      <input
+        type="password"
+        placeholder={t("newPassword")}
+        value={next}
+        onChange={(e) => setNext(e.target.value)}
+        className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+        onKeyPress={(e) => e.key === "Enter" && submit()}
+      />
+      {error && <p className="text-body text-danger">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy || !current.trim() || !next.trim()}
+          className="h-12 px-3.5 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {t("changePassword")}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setError(null);
+          }}
+          className="h-12 px-3.5 rounded-md border border-border text-label text-text-muted transition-colors hover:text-text cursor-pointer"
+        >
+          {t("cancel")}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChangePasswordSection;

--- a/frontend/src/components/customer/PastOrdersPanel.tsx
+++ b/frontend/src/components/customer/PastOrdersPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { ChevronLeft } from "lucide-react";
 import type { Drink, Order } from "../../types";
 import type { TranslationKeys } from "../../utils/translations";
+import ChangePasswordSection from "./ChangePasswordSection";
 
 interface PastOrdersPanelProps {
   orders: Order[];
@@ -193,6 +194,9 @@ const PastOrdersPanel: React.FC<PastOrdersPanelProps> = ({
             >
               {t("notMe")}
             </button>
+
+            {/* Only a regular — a guest who claimed their name — sees this. */}
+            <ChangePasswordSection />
           </div>
         </div>
       </aside>

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -33,6 +33,13 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     null
   );
   const [customerName, setCustomerName] = useStoredState("customerName", "");
+  // Whether the guest proved a password for their name — a "regular". Kept
+  // alongside the name so a reload knows to offer the things only a regular
+  // gets (changing their own password).
+  const [authenticated, setAuthenticated] = useStoredState<boolean>(
+    "authenticated",
+    false
+  );
   const [language, setLanguage] = useStoredState<Language>("language", "en");
   // Whether the guest picked a language by hand. Once they have, picking a bar
   // must not quietly switch it back to the bar's default.
@@ -69,6 +76,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setUserType(null);
     setCurrentBar(null);
     setCustomerName("");
+    setAuthenticated(false);
     setLanguage("en");
     setLanguageChosen(false);
     setBarForm({
@@ -84,6 +92,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setUserType,
     setCurrentBar,
     setCustomerName,
+    setAuthenticated,
     setLanguage,
     setLanguageChosen,
   ]);
@@ -114,7 +123,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
         const me = (await res.json()) as SignedIn;
         setUserType(me.userType);
         setCurrentBar(me.bar);
-        if (me.userType === "guest") setCustomerName(me.customerName ?? "");
+        if (me.userType === "guest") {
+          setCustomerName(me.customerName ?? "");
+          setAuthenticated(me.authenticated === true);
+        }
       } catch {
         // Offline or unreachable: leave the remembered state be.
       }
@@ -123,13 +135,21 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     return () => {
       cancelled = true;
     };
-  }, [userType, clearAllData, setUserType, setCurrentBar, setCustomerName]);
+  }, [
+    userType,
+    clearAllData,
+    setUserType,
+    setCurrentBar,
+    setCustomerName,
+    setAuthenticated,
+  ]);
 
   const value: AppContextType = {
     // App state
     userType,
     currentBar,
     customerName,
+    authenticated,
     language,
     languageChosen,
 
@@ -155,6 +175,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({
     setUserType,
     setCurrentBar,
     setCustomerName,
+    setAuthenticated,
     setLanguage,
     setLanguageChosen,
     setLoading,

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -25,6 +25,8 @@ export interface AppContextType {
   userType: UserType | null;
   currentBar: Bar | null;
   customerName: string;
+  /** A guest who proved a password for their name — a "regular". */
+  authenticated: boolean;
   language: Language;
   languageChosen: boolean;
 
@@ -50,6 +52,7 @@ export interface AppContextType {
   setUserType: (type: UserType | null) => void;
   setCurrentBar: (bar: Bar | null) => void;
   setCustomerName: (name: string) => void;
+  setAuthenticated: (value: boolean) => void;
   setLanguage: (lang: Language) => void;
   setLanguageChosen: (chosen: boolean) => void;
   setLoading: (loading: boolean) => void;

--- a/frontend/src/hooks/useGuestClaim.ts
+++ b/frontend/src/hooks/useGuestClaim.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+import { useApp } from "./useApp";
+import { useTranslation } from "../utils/translations";
+import { ApiError } from "../utils/api";
+
+/**
+ * The optional password on the guest login: setting one to claim a name, or
+ * typing one to prove a claimed name. Both doors — the QR scan and the
+ * shared-password form — share this, so the flow lives in one place and a fix
+ * to it lands in both.
+ */
+export function useGuestClaim() {
+  const { language } = useApp();
+  const t = useTranslation(language);
+
+  const [accountPassword, setAccountPassword] = useState("");
+  // On when the guest wants to make this name theirs (set a password).
+  const [claiming, setClaiming] = useState(false);
+  // On once the server says the name is already claimed, so we ask for its
+  // password rather than offering to set one.
+  const [nameClaimed, setNameClaimed] = useState(false);
+
+  /** Back to the quick path — for a cancel, or switching who is signing in. */
+  const reset = () => {
+    setAccountPassword("");
+    setClaiming(false);
+    setNameClaimed(false);
+  };
+
+  /** A different name is a different question: drop a stale "that name is
+   * registered" prompt when the guest edits their name. */
+  const onNameChange = () => {
+    if (nameClaimed) setNameClaimed(false);
+  };
+
+  /**
+   * Turns a failed sign-in into the message to show. A claimed name reveals the
+   * password field and returns null (nothing to say beyond the field itself); a
+   * wrong password says so; anything else passes its own message through.
+   */
+  const classify = (err: unknown, fallback: string): string | null => {
+    if (err instanceof ApiError && err.code === "name_claimed") {
+      setNameClaimed(true);
+      setClaiming(false);
+      return null;
+    }
+    if (err instanceof ApiError && err.code === "password_incorrect") {
+      return t("wrongPassword");
+    }
+    return err instanceof Error ? err.message : fallback;
+  };
+
+  return {
+    accountPassword,
+    setAccountPassword,
+    claiming,
+    setClaiming,
+    nameClaimed,
+    /** Show a password field: to prove a claimed name, or to set a new one. */
+    passwordVisible: nameClaimed || claiming,
+    /** The password to send, trimmed, or undefined when there is none. */
+    password: accountPassword.trim() || undefined,
+    onNameChange,
+    classify,
+    reset,
+  };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ export type {
   LiveUpdate,
   OperatorBar,
   OrderStatus,
+  Regular,
   SignedIn,
   UserType,
 } from "@shared/types";

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,22 @@
 const API_BASE = "/api";
 
 /**
+ * A failed request. Carries the status and, when the server sent one, a short
+ * code the pages can branch on — telling a claimed name apart from a wrong
+ * password without having to read the English message.
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code?: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/**
  * Talks to the API. Anything other than a success is turned into an error
  * carrying the message the server sent, which is what the pages show.
  *
@@ -27,7 +43,11 @@ export async function apiCall<T = unknown>(
       .json()
       .catch(() => ({ error: `HTTP ${response.status}` }));
 
-    throw new Error(problem.error || `HTTP ${response.status}`);
+    throw new ApiError(
+      problem.error || `HTTP ${response.status}`,
+      response.status,
+      problem.code
+    );
   }
 
   return response.json();

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -127,6 +127,15 @@ export interface TranslationMap {
   newPassword: string;
   passwordChanged: string;
 
+  // Regulars (bartender)
+  regulars: string;
+  regularsIntro: string;
+  noRegulars: string;
+  regularSince: string;
+  rename: string;
+  nameTaken: string;
+  guestRenamed: string;
+
   // Bartender interface
   pendingOrders: string;
   noPendingOrders: string;
@@ -408,6 +417,16 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     newPassword: "New password",
     passwordChanged: "Password changed.",
 
+    // Regulars (bartender)
+    regulars: "Regulars",
+    regularsIntro:
+      "Guests who have claimed their name here. Rename one to fix a name or tell two apart — let them know their new name next time.",
+    noRegulars: "No regulars yet.",
+    regularSince: "Regular since",
+    rename: "Rename",
+    nameTaken: "That name is already taken.",
+    guestRenamed: "Renamed.",
+
     // Bartender interface
     pendingOrders: "Pending Orders",
     noPendingOrders: "No pending orders",
@@ -686,6 +705,16 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     currentPassword: "Nuværende adgangskode",
     newPassword: "Ny adgangskode",
     passwordChanged: "Adgangskoden er skiftet.",
+
+    // Regulars (bartender)
+    regulars: "Faste gæster",
+    regularsIntro:
+      "Gæster der har gjort deres navn til deres her. Omdøb en for at rette et navn eller skelne to fra hinanden — fortæl dem deres nye navn næste gang.",
+    noRegulars: "Ingen faste gæster endnu.",
+    regularSince: "Fast gæst siden",
+    rename: "Omdøb",
+    nameTaken: "Det navn er allerede taget.",
+    guestRenamed: "Omdøbt.",
 
     // Bartender interface
     pendingOrders: "Afventende bestillinger",

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -115,6 +115,18 @@ export interface TranslationMap {
   rememberMe: string;
   rememberMeHelp: string;
 
+  // Claiming a name (regulars)
+  setPassword: string;
+  setPasswordHelp: string;
+  setAPassword: string;
+  yourPassword: string;
+  nameClaimedHelp: string;
+  wrongPassword: string;
+  changePassword: string;
+  currentPassword: string;
+  newPassword: string;
+  passwordChanged: string;
+
   // Bartender interface
   pendingOrders: string;
   noPendingOrders: string;
@@ -367,7 +379,7 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     goHome: "Go to the front page",
     loadingBar: "Fetching the bar…",
     landingIntro:
-      "Pick a bar, type your first name, and order from your phone. No account, no app.",
+      "Pick a bar, type your first name, and order from your phone. No account needed — or claim your name so it stays yours.",
     bartenderLogin: "Bartender Login",
     guestLogin: "Guest Login",
     createBar: "Create New Bar",
@@ -381,6 +393,20 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     enterName: "Enter Your Name",
     rememberMe: "Remember me on this phone",
     rememberMeHelp: "So you do not have to type your name again next time.",
+
+    // Claiming a name (regulars)
+    setPassword: "Make this name mine",
+    setPasswordHelp:
+      "Set a password so only you can use this name at this bar.",
+    setAPassword: "Choose a password",
+    yourPassword: "Your password",
+    nameClaimedHelp:
+      "This name is taken here. Enter its password — or add a last name or initial if it is not you.",
+    wrongPassword: "That password is not right.",
+    changePassword: "Change password",
+    currentPassword: "Current password",
+    newPassword: "New password",
+    passwordChanged: "Password changed.",
 
     // Bartender interface
     pendingOrders: "Pending Orders",
@@ -632,7 +658,7 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     goHome: "Gå til forsiden",
     loadingBar: "Henter baren…",
     landingIntro:
-      "Vælg en bar, skriv dit fornavn, og bestil fra telefonen. Ingen konto, ingen app.",
+      "Vælg en bar, skriv dit fornavn, og bestil fra telefonen. Ingen konto nødvendig — eller gør navnet til dit, så det bliver ved med at være dit.",
     bartenderLogin: "Bartender login",
     guestLogin: "Gæst login",
     createBar: "Opret ny bar",
@@ -646,6 +672,20 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     enterName: "Indtast dit navn",
     rememberMe: "Husk mig på denne telefon",
     rememberMeHelp: "Så du ikke skal skrive dit navn igen næste gang.",
+
+    // Claiming a name (regulars)
+    setPassword: "Gør dette navn til mit",
+    setPasswordHelp:
+      "Vælg en adgangskode, så kun du kan bruge dette navn i denne bar.",
+    setAPassword: "Vælg en adgangskode",
+    yourPassword: "Din adgangskode",
+    nameClaimedHelp:
+      "Dette navn er taget her. Indtast dets adgangskode — eller tilføj et efternavn eller et forbogstav, hvis det ikke er dig.",
+    wrongPassword: "Den adgangskode passer ikke.",
+    changePassword: "Skift adgangskode",
+    currentPassword: "Nuværende adgangskode",
+    newPassword: "Ny adgangskode",
+    passwordChanged: "Adgangskoden er skiftet.",
 
     // Bartender interface
     pendingOrders: "Afventende bestillinger",

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -135,6 +135,9 @@ export interface TranslationMap {
   rename: string;
   nameTaken: string;
   guestRenamed: string;
+  setGuestPassword: string;
+  setGuestPasswordHelp: string;
+  guestPasswordSet: string;
 
   // Bartender interface
   pendingOrders: string;
@@ -426,6 +429,10 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     rename: "Rename",
     nameTaken: "That name is already taken.",
     guestRenamed: "Renamed.",
+    setGuestPassword: "Set password",
+    setGuestPasswordHelp:
+      "Hand them the tablet to type a new one, or set a simple one they can change later.",
+    guestPasswordSet: "Password set.",
 
     // Bartender interface
     pendingOrders: "Pending Orders",
@@ -715,6 +722,10 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     rename: "Omdøb",
     nameTaken: "Det navn er allerede taget.",
     guestRenamed: "Omdøbt.",
+    setGuestPassword: "Vælg adgangskode",
+    setGuestPasswordHelp:
+      "Ræk dem tabletten, så de selv kan skrive en ny, eller vælg en simpel en, de kan ændre senere.",
+    guestPasswordSet: "Adgangskoden er sat.",
 
     // Bartender interface
     pendingOrders: "Afventende bestillinger",

--- a/frontend/tests/claimName.test.tsx
+++ b/frontend/tests/claimName.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import LoginForm from "../src/components/LoginForm";
+import { AppProvider } from "../src/context/AppContext";
+import { aBar } from "./helpers";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+function renderGuestLogin() {
+  return render(
+    <MemoryRouter>
+      <AppProvider>
+        <LoginForm mode="guest" prefilledBarId="1" onBack={() => {}} />
+      </AppProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("claiming a name from the guest login", () => {
+  it("asks for the password when the name is already registered", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    let call = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, opts: RequestInit = {}) => {
+        const path = String(url);
+        if (path.endsWith("/api/auth/guest")) {
+          bodies.push(JSON.parse(String(opts.body)));
+          call += 1;
+          // First try: no name password, and the name is claimed.
+          if (call === 1) {
+            return {
+              ok: false,
+              status: 401,
+              json: async () => ({ error: "registered", code: "name_claimed" }),
+            } as Response;
+          }
+          // Second try: the right password gets them in as a regular.
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              success: true,
+              userType: "guest",
+              bar: aBar(),
+              customerName: "Ada",
+              authenticated: true,
+            }),
+          } as Response;
+        }
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      })
+    );
+
+    renderGuestLogin();
+
+    // Type the bar's shared password and a name, then try to go in.
+    fireEvent.change(await screen.findByPlaceholderText("Enter Password"), {
+      target: { value: "gin" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter Your Name"), {
+      target: { value: "Ada" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    // The name is taken: a password field and an explanation appear.
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Your password")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/this name is taken here/i)).toBeInTheDocument();
+
+    // Prove it, and the second request carries the name's password.
+    fireEvent.change(screen.getByPlaceholderText("Your password"), {
+      target: { value: "secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => expect(bodies).toHaveLength(2));
+    expect(bodies[1]).toMatchObject({
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+  });
+
+  it("sends no password on the quick path for an unclaimed name", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, opts: RequestInit = {}) => {
+        const path = String(url);
+        if (path.endsWith("/api/auth/guest")) {
+          bodies.push(JSON.parse(String(opts.body)));
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              success: true,
+              userType: "guest",
+              bar: aBar(),
+              customerName: "Bea",
+              authenticated: false,
+            }),
+          } as Response;
+        }
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      })
+    );
+
+    renderGuestLogin();
+
+    fireEvent.change(await screen.findByPlaceholderText("Enter Password"), {
+      target: { value: "gin" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter Your Name"), {
+      target: { value: "Bea" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    // The quick path carries no name password at all.
+    expect(bodies[0]).not.toHaveProperty("accountPassword");
+  });
+});

--- a/frontend/tests/regulars.test.tsx
+++ b/frontend/tests/regulars.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import RegularsTab from "../src/components/bartender/RegularsTab";
+import { withApp, fakeApi, aBar, signIn } from "./helpers";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+type Row = { id: number; name: string; created_at: string };
+
+/** Serves a mutable list of regulars and applies a rename to it. */
+function fakeRegulars(initial: Row[]) {
+  let list = initial;
+  return fakeApi((path, options) => {
+    if (path.includes("/auth/me")) {
+      return { success: true, userType: "bartender", bar: aBar() };
+    }
+    if (path.includes("/regulars/") && options.method === "PUT") {
+      const { name } = JSON.parse(String(options.body));
+      list = list.map((r) => (path.endsWith(`/${r.id}`) ? { ...r, name } : r));
+      return { id: 1, name, created_at: initial[0].created_at };
+    }
+    if (path.includes("/regulars")) return list;
+    return undefined;
+  });
+}
+
+describe("the bartender's regulars tab", () => {
+  it("lists the regulars who claimed a name", async () => {
+    fakeRegulars([
+      { id: 1, name: "Ada", created_at: "2026-08-01" },
+      { id: 2, name: "Bea", created_at: "2026-08-02" },
+    ]);
+    signIn({ as: "bartender" });
+
+    render(<RegularsTab />, { wrapper: withApp });
+
+    expect(await screen.findByText("Ada")).toBeInTheDocument();
+    expect(screen.getByText("Bea")).toBeInTheDocument();
+  });
+
+  it("renames a regular and shows the new name", async () => {
+    fakeRegulars([{ id: 1, name: "Ada", created_at: "2026-08-01" }]);
+    signIn({ as: "bartender" });
+
+    render(<RegularsTab />, { wrapper: withApp });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Rename" }));
+
+    const input = screen.getByDisplayValue("Ada");
+    fireEvent.change(input, { target: { value: "Ada Lovelace" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/regulars.test.tsx
+++ b/frontend/tests/regulars.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import RegularsTab from "../src/components/bartender/RegularsTab";
 import { withApp, fakeApi, aBar, signIn } from "./helpers";
@@ -17,6 +17,9 @@ function fakeRegulars(initial: Row[]) {
   return fakeApi((path, options) => {
     if (path.includes("/auth/me")) {
       return { success: true, userType: "bartender", bar: aBar() };
+    }
+    if (path.endsWith("/password") && options.method === "PUT") {
+      return { success: true };
     }
     if (path.includes("/regulars/") && options.method === "PUT") {
       const { name } = JSON.parse(String(options.body));
@@ -55,5 +58,23 @@ describe("the bartender's regulars tab", () => {
     fireEvent.keyDown(input, { key: "Enter" });
 
     expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument();
+  });
+
+  it("resets a regular's password on the bartender's say-so", async () => {
+    const api = fakeRegulars([{ id: 1, name: "Ada", created_at: "2026-08-01" }]);
+    signIn({ as: "bartender" });
+
+    render(<RegularsTab />, { wrapper: withApp });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Set password" }));
+
+    // The bartender (or the guest they hand the tablet to) types a new one.
+    const input = screen.getByPlaceholderText("New password");
+    fireEvent.change(input, { target: { value: "simple" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // It went to the password endpoint, and the row confirms it.
+    await waitFor(() => expect(api.countOf("/password")).toBe(1));
+    expect(await screen.findByText("Password set.")).toBeInTheDocument();
   });
 });

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -115,6 +115,16 @@ export interface SignedIn {
 }
 
 /**
+ * A regular the bartender can see: a guest who claimed their name at this bar.
+ * No password ever leaves the server, so only the name and when it was claimed.
+ */
+export interface Regular {
+  id: number;
+  name: string;
+  created_at: string;
+}
+
+/**
  * One bar as the operator panel sees it: enough to tell live bars apart, spot a
  * dead one, and know when each was last used. The operator sees retired bars
  * too, which is why `deletedAt` is here and not on the guest-facing `Bar`.

--- a/shared/types.d.ts
+++ b/shared/types.d.ts
@@ -107,6 +107,11 @@ export interface SignedIn {
   bar: Bar;
   /** Only when a guest signs in. */
   customerName?: string;
+  /**
+   * A guest who proved a password for their name — a "regular". Absent or false
+   * for a one-time guest, who typed a name nobody has claimed.
+   */
+  authenticated?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #56.

A guest's name was taken on trust — anyone could type "Ada" and inherit Ada's favourites and past orders. This lets a **regular** claim their name at a bar with a password, so it's actually theirs, while a **one-time guest** still just types a name and walks in. Builds on the session work from #53.

## How it works

- **One-time guest** (unchanged): scan the QR or use the shared password, type a name, in.
- **Regular**: the first time, tick "make this name mine" and set a password — that claims the name. Every later visit, name + password, and their favourites and history are guaranteed theirs. On the same phone the cookie remembers them.

Enforcement lives entirely at **sign-in**: a claimed name can't get a session without its password, so an anonymous namesake is turned away at the door. Because of that, favourites and past-order routes are untouched — **every existing guest keeps access to their history by name**, and nothing name-keyed moves. Claiming is a pure opt-in lock on top.

## What's in it

**Data** — one new table, one dated migration. Favourites and orders stay keyed by the name string.
```sql
CREATE TABLE guest_accounts (
  id, bar_id, name, password_hash, created_at,
  UNIQUE(bar_id, name COLLATE NOCASE)
);
```

**Backend**
- Both guest doors (`/api/auth/guest`, `/api/bars/:id/guest-token-login`) resolve the name before setting the cookie: claimed → prove; unclaimed + password → claim; unclaimed + no password → anonymous.
- The session cookie carries `authenticated` (a proven regular). `SignedIn` gains the same flag.
- Guest cookies now last 30 days (`GUEST_SESSION_TTL_DAYS`) vs the bartender's 24h, so a regular isn't signed out over a weekend.
- Regulars can change their own password. `HttpError` gained an optional `code` so the pages tell "this name is registered" apart from "wrong password" without reading English.

**Guest UI**
- One name field, as before. A claimed name reveals a password field with a note to add a last name or initial if it isn't you; an unclaimed name gets an unobtrusive "make this name mine" checkbox. The shared claim/reveal/error flow lives in one `useGuestClaim` hook both login doors use.
- A regular can change their password from the past-orders panel; a one-time guest never sees that control.
- Landing copy notes the optional account.

**Bartender UI** — a new **Regulars** screen (owner request, beyond the issue):
- Lists who's claimed a name here; never carries a password.
- **Rename** a regular, carrying their favourites and past orders to the new name in one transaction — the deliberate, admin-run rename the guest side purposely doesn't offer. The bartender tells them their new name next visit.
- **Set password** for a regular without asking for the old one — hand the tablet over for them to type a new one, or set a simple one they change later. Also the way back in for a regular who forgot theirs.

## Tests
Backend 171, frontend 103 — all passing; lint, typecheck, and build clean on both halves. Covers the three-way sign-in branch, the login-time invariant, existing favourites surviving a claim, rename moving history, the collision guard, and both bartender password paths.

## Before merging / releasing
- **Danish strings** across the feature were written by me and are flagged for a native review (per the repo's translation rule).
- The migration only adds a table, but per the project rules it's worth running against a **copy of a real database** first — this environment had none to test against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KoowGibs2wVbYS6bVWjes)_