### PR TITLE
Move registering out of the login and into the bar

### DIFF
--- a/backend/src/auth/guestAccounts.ts
+++ b/backend/src/auth/guestAccounts.ts
@@ -104,6 +104,43 @@ export async function resolveGuest(
 }
 
 /**
+ * Claims a name for a guest who is already signed in under it — the "make this
+ * name yours" step taken inside the bar, not at the door. The name must still
+ * be free; a signed-in anonymous guest always holds a free one.
+ */
+export async function claimGuestName(
+  db: Db,
+  barId: number,
+  name: string,
+  password: string
+): Promise<void> {
+  if (findGuestAccount(db, barId, name)) {
+    throw new HttpError(409, "That name is already claimed", NAME_CLAIMED);
+  }
+
+  const pw = password.trim();
+  if (pw.length < GUEST_PASSWORD_MIN) {
+    throw HttpError.badRequest(
+      `Password must be at least ${GUEST_PASSWORD_MIN} characters long`
+    );
+  }
+
+  const passwordHash = await bcrypt.hash(pw, HASH_ROUNDS);
+  try {
+    run(
+      db,
+      "INSERT INTO guest_accounts (bar_id, name, password_hash) VALUES (?, ?, ?)",
+      barId,
+      name,
+      passwordHash
+    );
+  } catch (err) {
+    if (!isUniqueViolation(err)) throw err;
+    throw new HttpError(409, "That name was just claimed", NAME_CLAIMED);
+  }
+}
+
+/**
  * Changes a claimed name's password. The caller has already proved they are the
  * regular whose name this is.
  */

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -13,8 +13,16 @@ import {
   clearSessionCookie,
   setSessionCookie,
 } from "../auth/session.js";
-import { currentSession, requireRegular } from "../auth/middleware.js";
-import { changeGuestPassword, resolveGuest } from "../auth/guestAccounts.js";
+import {
+  currentSession,
+  requireGuest,
+  requireRegular,
+} from "../auth/middleware.js";
+import {
+  changeGuestPassword,
+  claimGuestName,
+  resolveGuest,
+} from "../auth/guestAccounts.js";
 import {
   findBar,
   publicBar,
@@ -133,6 +141,25 @@ export default function createAuthRoutes(db: Db): Router {
           ? { ...reply, customerName: session.name }
           : reply
       );
+    })
+  );
+
+  // "Make this name yours": a guest already signed in under a name sets a
+  // password on it, from inside the bar. It claims the name and their session
+  // becomes a regular's, so the longer-lived things open up on the next reload.
+  router.post(
+    "/guest/claim",
+    route(async (req, res) => {
+      const { barId, name } = requireGuest(res);
+      const password = requireText(req.body, "password", { label: "Password" });
+
+      await claimGuestName(db, barId, name, password);
+
+      // Re-issue the cookie as a proven regular, so the claim sticks.
+      setSessionCookie(res, { barId, role: "guest", name, authenticated: true });
+
+      const bar = findBar(db, barId);
+      res.json({ ...signedInAs(bar, "guest", true), customerName: name });
     })
   );
 

--- a/backend/tests/guest-accounts.test.ts
+++ b/backend/tests/guest-accounts.test.ts
@@ -380,6 +380,65 @@ describe("the bartender resetting a regular's password", () => {
   });
 });
 
+describe("claiming a name from inside the bar", () => {
+  it("lets a signed-in guest set a password and become a regular", async () => {
+    const { app, db } = makeTestApp();
+    const { barId, token } = seedBarWithToken(db);
+
+    const res = await request(app)
+      .post("/api/auth/guest/claim")
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Ada" }))
+      .send({ password: "secret" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.authenticated).toBe(true);
+    expect(res.body.customerName).toBe("Ada");
+
+    // The name is claimed now: proving it at the door works, and a bare login
+    // is turned away.
+    const proved = await tokenLogin(app, barId, token, {
+      customerName: "Ada",
+      accountPassword: "secret",
+    });
+    expect(proved.status).toBe(200);
+    expect(proved.body.authenticated).toBe(true);
+
+    const bare = await tokenLogin(app, barId, token, { customerName: "Ada" });
+    expect(bare.status).toBe(401);
+  });
+
+  it("refuses a name that is already claimed", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+    db.prepare(
+      "INSERT INTO guest_accounts (bar_id, name, password_hash) VALUES (?, 'Ada', 'x')"
+    ).run(barId);
+
+    const res = await request(app)
+      .post("/api/auth/guest/claim")
+      .set("Cookie", sessionCookie({ barId, role: "guest", name: "Ada" }))
+      .send({ password: "secret" });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("is only for a signed-in guest", async () => {
+    const { app, db } = makeTestApp();
+    const { barId } = seedBar(db);
+
+    const noCookie = await request(app)
+      .post("/api/auth/guest/claim")
+      .send({ password: "secret" });
+    expect(noCookie.status).toBe(401);
+
+    const asBartender = await request(app)
+      .post("/api/auth/guest/claim")
+      .set("Cookie", sessionCookie({ barId, role: "bartender" }))
+      .send({ password: "secret" });
+    expect(asBartender.status).toBe(403);
+  });
+});
+
 describe("changing a regular's password", () => {
   it("turns away a one-time guest who never claimed a name", async () => {
     const { app, db } = makeTestApp();

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -204,32 +204,22 @@ const LoginForm: React.FC<LoginFormProps> = ({
                 onKeyPress={(e) => e.key === "Enter" && handleLogin()}
               />
 
-              {/* A claimed name has to be proved with its password. */}
+              {/* A claimed name has to be proved with its password — the only
+                  time the door asks for one. Registering happens inside. */}
               {claim.nameClaimed && (
-                <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
-              )}
-
-              {/* Otherwise, an unobtrusive way to make this name yours. */}
-              {!claim.nameClaimed && (
-                <ToggleRow
-                  on={claim.claiming}
-                  onChange={claim.setClaiming}
-                  title={t("setPassword")}
-                  help={t("setPasswordHelp")}
-                />
-              )}
-
-              {claim.passwordVisible && (
-                <input
-                  type="password"
-                  placeholder={
-                    claim.nameClaimed ? t("yourPassword") : t("setAPassword")
-                  }
-                  value={claim.accountPassword}
-                  onChange={(e) => claim.setAccountPassword(e.target.value)}
-                  className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
-                  onKeyPress={(e) => e.key === "Enter" && handleLogin()}
-                />
+                <>
+                  <p className="text-sm text-text-muted">
+                    {t("nameClaimedHelp")}
+                  </p>
+                  <input
+                    type="password"
+                    placeholder={t("yourPassword")}
+                    value={claim.accountPassword}
+                    onChange={(e) => claim.setAccountPassword(e.target.value)}
+                    className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+                    onKeyPress={(e) => e.key === "Enter" && handleLogin()}
+                  />
+                </>
               )}
 
               <ToggleRow

--- a/frontend/src/components/QRRedirect.tsx
+++ b/frontend/src/components/QRRedirect.tsx
@@ -207,33 +207,23 @@ const QRRedirect: React.FC = () => {
                 autoFocus
               />
 
-              {/* A claimed name has to be proved with its password. */}
+              {/* A claimed name has to be proved with its password — the only
+                  time the door asks for one. Registering happens inside. */}
               {claim.nameClaimed && (
-                <p className="text-sm text-text-muted">{t("nameClaimedHelp")}</p>
-              )}
-
-              {/* Otherwise, an unobtrusive way to make this name yours. */}
-              {!claim.nameClaimed && (
-                <ToggleRow
-                  on={claim.claiming}
-                  onChange={claim.setClaiming}
-                  title={t("setPassword")}
-                  help={t("setPasswordHelp")}
-                />
-              )}
-
-              {claim.passwordVisible && (
-                <input
-                  type="password"
-                  placeholder={
-                    claim.nameClaimed ? t("yourPassword") : t("setAPassword")
-                  }
-                  value={claim.accountPassword}
-                  onChange={(e) => claim.setAccountPassword(e.target.value)}
-                  className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
-                  onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
-                  autoFocus={claim.nameClaimed}
-                />
+                <>
+                  <p className="text-sm text-text-muted">
+                    {t("nameClaimedHelp")}
+                  </p>
+                  <input
+                    type="password"
+                    placeholder={t("yourPassword")}
+                    value={claim.accountPassword}
+                    onChange={(e) => claim.setAccountPassword(e.target.value)}
+                    className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+                    onKeyPress={(e) => e.key === "Enter" && handleGuestLogin()}
+                    autoFocus
+                  />
+                </>
               )}
 
               <ToggleRow

--- a/frontend/src/components/customer/ClaimNameModal.tsx
+++ b/frontend/src/components/customer/ClaimNameModal.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { useApp } from "../../hooks/useApp";
+import { useTranslation } from "../../utils/translations";
+
+const PASSWORD_MIN = 4;
+
+interface ClaimNameModalProps {
+  onClose: () => void;
+}
+
+/**
+ * "Make this name yours": a small dialog where a signed-in guest sets a password
+ * on their name, claiming it. On success the greeting behind it turns into a
+ * "welcome back", so the modal just confirms and closes.
+ */
+const ClaimNameModal: React.FC<ClaimNameModalProps> = ({ onClose }) => {
+  const { customerName, language, apiCall, setAuthenticated } = useApp();
+  const t = useTranslation(language);
+
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  // Escape closes it, the same as the labelled way out.
+  useEffect(() => {
+    const close = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", close);
+    return () => window.removeEventListener("keydown", close);
+  }, [onClose]);
+
+  const submit = async () => {
+    if (password.trim().length < PASSWORD_MIN) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiCall("/auth/guest/claim", {
+        method: "POST",
+        body: JSON.stringify({ password: password.trim() }),
+      });
+      setAuthenticated(true);
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("setPasswordHelp"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-overlay flex items-center justify-center p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("setPassword")}
+        className="bg-surface-raised border border-border rounded-lg shadow-float w-full max-w-sm"
+      >
+        <div className="p-5 border-b border-border flex items-start gap-3">
+          <h3 className="flex-1 text-heading">
+            {t("setPassword")}
+            {customerName ? ` — ${customerName}` : ""}
+          </h3>
+          <button
+            onClick={onClose}
+            aria-label={t("cancel")}
+            className="-m-2 w-11 h-11 shrink-0 flex items-center justify-center rounded-md text-text-muted transition-colors duration-(--duration-instant) hover:text-text cursor-pointer"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {done ? (
+          <div className="p-5 flex flex-col gap-4">
+            <p className="text-body text-text-muted">{t("nameIsYours")}</p>
+            <button
+              onClick={onClose}
+              className="h-14 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 cursor-pointer"
+            >
+              {t("close")}
+            </button>
+          </div>
+        ) : (
+          <div className="p-5 flex flex-col gap-4">
+            <p className="text-body text-text-muted">{t("setPasswordHelp")}</p>
+            <input
+              type="password"
+              placeholder={t("setAPassword")}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full p-3 border border-border rounded-md focus:ring-2 focus:border-transparent"
+              onKeyPress={(e) => e.key === "Enter" && submit()}
+              autoFocus
+            />
+            {error && <p className="text-body text-danger">{error}</p>}
+            <div className="flex flex-col sm:flex-row gap-2.5">
+              <button
+                onClick={submit}
+                disabled={busy || password.trim().length < PASSWORD_MIN}
+                className="flex-1 h-14 rounded-md bg-text text-text-inverse text-label transition-colors hover:bg-neutral-800 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                {t("setPassword")}
+              </button>
+              <button
+                onClick={onClose}
+                className="flex-1 h-14 rounded-md border border-border text-label transition-colors hover:bg-surface-sunken cursor-pointer"
+              >
+                {t("cancel")}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ClaimNameModal;

--- a/frontend/src/components/customer/GuestGreeting.tsx
+++ b/frontend/src/components/customer/GuestGreeting.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { useApp } from "../../hooks/useApp";
+import type { Order } from "../../types";
+import { useTranslation } from "../../utils/translations";
+import ClaimNameModal from "./ClaimNameModal";
+
+/** The date of the guest's most recent visit before today, or null. Read off
+ * their own orders — created_at is a fixed "YYYY-MM-DD …", so it sorts as text. */
+function lastVisitBeforeToday(orders: Order[], name: string): string | null {
+  const today = new Date().toDateString();
+  const prior = orders
+    .filter(
+      (o) =>
+        o.customer_name === name &&
+        new Date(o.created_at).toDateString() !== today
+    )
+    .map((o) => o.created_at)
+    .sort();
+  const latest = prior[prior.length - 1];
+  return latest ? new Date(latest).toLocaleDateString() : null;
+}
+
+/**
+ * The header greeting. A regular is welcomed back with their last visit; a
+ * one-time guest is invited — on a quiet second line — to make the name theirs,
+ * which opens the claim dialog. This is the one place registering is offered.
+ */
+const GuestGreeting: React.FC = () => {
+  const { authenticated, customerName, orders, language } = useApp();
+  const t = useTranslation(language);
+  const [claiming, setClaiming] = useState(false);
+
+  const lastVisit = authenticated
+    ? lastVisitBeforeToday(orders, customerName)
+    : null;
+
+  return (
+    <div className="sm:flex-1 min-w-0 flex flex-col gap-0.5">
+      <p className="text-body text-text-muted truncate">
+        {authenticated ? t("greetingBack") : t("greeting")}, {customerName}
+      </p>
+
+      {!authenticated ? (
+        <button
+          type="button"
+          onClick={() => setClaiming(true)}
+          className="self-start text-caption text-text-muted underline decoration-dotted underline-offset-2 transition-colors duration-(--duration-instant) hover:text-text cursor-pointer"
+        >
+          {t("setPassword")}
+        </button>
+      ) : (
+        lastVisit && (
+          <p className="text-caption text-text-muted truncate">
+            {t("lastVisited")} {lastVisit}
+          </p>
+        )
+      )}
+
+      {claiming && <ClaimNameModal onClose={() => setClaiming(false)} />}
+    </div>
+  );
+};
+
+export default GuestGreeting;

--- a/frontend/src/components/customer/GuestShell.tsx
+++ b/frontend/src/components/customer/GuestShell.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "../../utils/translations";
 import { ConnectionLost } from "../ConnectionLost";
 import ThemeToggle from "../ThemeToggle";
 import GuestDock from "./GuestDock";
+import GuestGreeting from "./GuestGreeting";
 
 /** Statuses that mean a guest still has a drink on the go. */
 const IN_PROGRESS = ["new", "accepted", "ready"];
@@ -82,9 +83,7 @@ const GuestShell: React.FC<GuestShellProps> = ({
 
             <div className="flex-1 min-w-0 flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-4">
               <h1 className="text-heading truncate">{currentBar?.name}</h1>
-              <p className="sm:flex-1 min-w-0 text-body text-text-muted truncate">
-                {t("greeting")}, {customerName}
-              </p>
+              <GuestGreeting />
             </div>
 
             <ThemeToggle t={t} />

--- a/frontend/src/components/customer/PastOrdersPanel.tsx
+++ b/frontend/src/components/customer/PastOrdersPanel.tsx
@@ -195,7 +195,8 @@ const PastOrdersPanel: React.FC<PastOrdersPanelProps> = ({
               {t("notMe")}
             </button>
 
-            {/* Only a regular — a guest who claimed their name — sees this. */}
+            {/* A regular — a guest who claimed their name — can change their
+                password here. Claiming itself is offered up in the greeting. */}
             <ChangePasswordSection />
           </div>
         </div>

--- a/frontend/src/hooks/useGuestClaim.ts
+++ b/frontend/src/hooks/useGuestClaim.ts
@@ -4,26 +4,23 @@ import { useTranslation } from "../utils/translations";
 import { ApiError } from "../utils/api";
 
 /**
- * The optional password on the guest login: setting one to claim a name, or
- * typing one to prove a claimed name. Both doors — the QR scan and the
- * shared-password form — share this, so the flow lives in one place and a fix
- * to it lands in both.
+ * Proving a claimed name at the guest login. Registering a name happens inside
+ * the bar, not here — so the login only ever asks for a password when the name
+ * is already someone's. Both doors (the QR scan and the shared-password form)
+ * share this, so a fix to it lands in both.
  */
 export function useGuestClaim() {
   const { language } = useApp();
   const t = useTranslation(language);
 
   const [accountPassword, setAccountPassword] = useState("");
-  // On when the guest wants to make this name theirs (set a password).
-  const [claiming, setClaiming] = useState(false);
   // On once the server says the name is already claimed, so we ask for its
-  // password rather than offering to set one.
+  // password as a second step.
   const [nameClaimed, setNameClaimed] = useState(false);
 
   /** Back to the quick path — for a cancel, or switching who is signing in. */
   const reset = () => {
     setAccountPassword("");
-    setClaiming(false);
     setNameClaimed(false);
   };
 
@@ -41,7 +38,6 @@ export function useGuestClaim() {
   const classify = (err: unknown, fallback: string): string | null => {
     if (err instanceof ApiError && err.code === "name_claimed") {
       setNameClaimed(true);
-      setClaiming(false);
       return null;
     }
     if (err instanceof ApiError && err.code === "password_incorrect") {
@@ -53,11 +49,9 @@ export function useGuestClaim() {
   return {
     accountPassword,
     setAccountPassword,
-    claiming,
-    setClaiming,
+    /** True once the name turned out to be claimed: show a password field. */
     nameClaimed,
-    /** Show a password field: to prove a claimed name, or to set a new one. */
-    passwordVisible: nameClaimed || claiming,
+    passwordVisible: nameClaimed,
     /** The password to send, trimmed, or undefined when there is none. */
     password: accountPassword.trim() || undefined,
     onNameChange,

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -23,6 +23,8 @@ export interface TranslationMap {
   yourName: string;
   startOrdering: string;
   greeting: string;
+  greetingBack: string;
+  lastVisited: string;
   letTheBarChoose: string;
   confirmReject: string;
   bartender: string;
@@ -126,6 +128,7 @@ export interface TranslationMap {
   currentPassword: string;
   newPassword: string;
   passwordChanged: string;
+  nameIsYours: string;
 
   // Regulars (bartender)
   regulars: string;
@@ -306,6 +309,8 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     yourName: "Your name",
     startOrdering: "Start ordering",
     greeting: "Welcome",
+    greetingBack: "Welcome back",
+    lastVisited: "You last visited on",
     letTheBarChoose: "Let the bar choose",
     confirmReject: "Reject this order? The guest is told straight away.",
     bartender: "Bartender",
@@ -419,6 +424,7 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     currentPassword: "Current password",
     newPassword: "New password",
     passwordChanged: "Password changed.",
+    nameIsYours: "This name is yours now — you will need this password next time.",
 
     // Regulars (bartender)
     regulars: "Regulars",
@@ -599,6 +605,8 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     yourName: "Dit navn",
     startOrdering: "Kom i gang",
     greeting: "Velkommen",
+    greetingBack: "Velkommen tilbage",
+    lastVisited: "Du var her sidst den",
     letTheBarChoose: "Lad baren vælge",
     confirmReject: "Afvis denne bestilling? Gæsten får besked med det samme.",
     bartender: "Bartender",
@@ -712,6 +720,7 @@ export const translations: { en: TranslationMap; da: TranslationMap } = {
     currentPassword: "Nuværende adgangskode",
     newPassword: "Ny adgangskode",
     passwordChanged: "Adgangskoden er skiftet.",
+    nameIsYours: "Navnet er dit nu — du skal bruge denne adgangskode næste gang.",
 
     // Regulars (bartender)
     regulars: "Faste gæster",

--- a/frontend/tests/claimGreeting.test.tsx
+++ b/frontend/tests/claimGreeting.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+
+import GuestGreeting from "../src/components/customer/GuestGreeting";
+import { withApp, fakeApi, aBar, signIn } from "./helpers";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+const CLAIM = "Make this name mine";
+
+describe("the header greeting", () => {
+  it("invites an anonymous guest to claim, then welcomes them back", async () => {
+    const api = fakeApi((path) => {
+      if (path.includes("/auth/me")) {
+        return {
+          success: true,
+          userType: "guest",
+          bar: aBar(),
+          customerName: "Ada",
+          authenticated: false,
+        };
+      }
+      if (path.includes("/auth/guest/claim")) {
+        return {
+          success: true,
+          userType: "guest",
+          bar: aBar(),
+          customerName: "Ada",
+          authenticated: true,
+        };
+      }
+      return undefined;
+    });
+    signIn({ as: "guest", name: "Ada" });
+
+    render(<GuestGreeting />, { wrapper: withApp });
+
+    // Anonymous: a plain welcome, with an invitation to claim on the 2nd line.
+    expect(await screen.findByText(/welcome, ada/i)).toBeInTheDocument();
+
+    // The invitation opens a modal; set a password there.
+    fireEvent.click(screen.getByRole("button", { name: CLAIM }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(
+      within(dialog).getByPlaceholderText("Choose a password"),
+      { target: { value: "secret" } }
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: CLAIM }));
+
+    await waitFor(() => expect(api.countOf("/auth/guest/claim")).toBe(1));
+    // Now a regular: the greeting turns into a welcome back.
+    expect(await screen.findByText(/welcome back, ada/i)).toBeInTheDocument();
+  });
+
+  it("welcomes a regular back with their last visit", async () => {
+    fakeApi((path) => {
+      if (path.includes("/auth/me")) {
+        return {
+          success: true,
+          userType: "guest",
+          bar: aBar(),
+          customerName: "Ada",
+          authenticated: true,
+        };
+      }
+      return undefined;
+    });
+    signIn({ as: "guest", name: "Ada" });
+    localStorage.setItem("homeBarSystem_authenticated", JSON.stringify(true));
+
+    render(<GuestGreeting />, { wrapper: withApp });
+
+    expect(await screen.findByText(/welcome back, ada/i)).toBeInTheDocument();
+    // No claim invitation for someone who already registered.
+    expect(screen.queryByRole("button", { name: CLAIM })).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #65 (issue #56). Testing the shipped flow surfaced a UX problem: the guest login carried a "make this name mine" checkbox on **every** sign-in, so registering looked like a save-my-login prompt you could do each time.

## The change

**Login only ever asks for a password to *prove* an already-claimed name.** The "set a password to register" affordance is gone from both login doors (the QR scan and the shared-password form). An unclaimed name just walks in.

**Registering moved into the bar, onto the header greeting:**
- A one-time guest is welcomed by name — *Welcome, Ada* — with a quiet second line inviting them to make the name theirs. Tapping it opens a **small modal** to set a password, which claims the name and turns them into a regular in place.
- A regular is welcomed back — *Welcome back, Ada* — with the date of their **last visit** underneath (read from their own past orders; shown only when there's a prior-day visit).

## Backend
- New `POST /api/auth/guest/claim`: a guest already signed in under a name sets a password on it; the cookie is re-issued as a proven regular. Guarded by `requireGuest`, rejects an already-claimed name.
- The login endpoints and `resolveGuest` are unchanged.

## Frontend
- New `GuestGreeting` (in the guest header) and `ClaimNameModal`.
- The shared `useGuestClaim` hook shrinks to just the prove-a-claimed-name case.
- The claim control was removed from the past-orders panel (change-password stays there for regulars).

## Tests
Backend 174, frontend 105 — all passing; lint, typecheck, build clean on both halves. Covers the new claim endpoint (signed-in guest claims, already-claimed rejected, guest-only) and the greeting flow (anonymous → claim modal → welcomed back; regular sees no invitation).

## Before releasing
- **Danish strings** (the new greeting/last-visit/modal wording) want a native review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KoowGibs2wVbYS6bVWjes)_