### PR TITLE
Walk a signed-in guest back in when they tap their own bar

### DIFF
--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -9,7 +9,9 @@ import LoginForm from "./LoginForm";
 
 const LandingPage: React.FC = () => {
   const {
+    userType,
     currentBar,
+    customerName,
     language,
     languageChosen,
     setLanguage,
@@ -22,6 +24,14 @@ const LandingPage: React.FC = () => {
 
   const [mode, setMode] = useState<"select" | "create" | "login">("select");
   const [selectedBar, setSelectedBar] = useState<Bar | null>(null);
+
+  // The bar this visitor is already signed into, remembered as the page opens
+  // — before picking a bar starts overwriting currentBar. Tapping this same bar
+  // means "back to where I was", not "sign in again". A different bar still
+  // goes through the login, so swapping bars works as before.
+  const signedIn = useRef(
+    userType && currentBar ? { role: userType, barId: currentBar.id } : null
+  );
 
   // The way in to the operator panel: tap the sign seven times, quickly. There
   // is deliberately no link to it anywhere — this is the whole door. The real
@@ -39,6 +49,21 @@ const LandingPage: React.FC = () => {
   };
 
   const handleSelectBar = (bar: Bar) => {
+    // Already signed in on this bar: walk back in rather than asking again.
+    // A guest still needs a remembered name to have somewhere to return to.
+    if (signedIn.current?.barId === bar.id) {
+      if (signedIn.current.role === "guest" && customerName) {
+        setCurrentBar(bar);
+        navigate("/customer");
+        return;
+      }
+      if (signedIn.current.role === "bartender") {
+        setCurrentBar(bar);
+        navigate("/bartender");
+        return;
+      }
+    }
+
     setSelectedBar(bar);
     setCurrentBar(bar);
     // A guest who picked a language keeps it; otherwise fall back to the bar's.

--- a/frontend/tests/landingRedirect.test.tsx
+++ b/frontend/tests/landingRedirect.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import App from "../src/App";
+import { aBar, aDrink, fakeApi, FakeEventSource, signIn } from "./helpers";
+
+const OTHER_BAR = aBar({ id: 2, name: "The Anchor" });
+
+const serve = () =>
+  fakeApi((path) => {
+    if (path.includes("/favourites/")) return [];
+    if (path.includes("/drinks/bar/")) return [aDrink({ id: 1 })];
+    if (path.includes("/orders/bar/")) return [];
+    if (path.includes("/bars/1")) return aBar();
+    if (path === "/api/bars") return [aBar(), OTHER_BAR];
+    return undefined;
+  });
+
+const openFrontDoor = () => {
+  window.history.pushState({}, "", "/");
+  return render(<App />);
+};
+
+beforeEach(() => {
+  FakeEventSource.reset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+  serve();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.pushState({}, "", "/");
+});
+
+// Closing the tab or trimming "/customer" off the address drops the guest back
+// on the front door. Their session is still good, so tapping the bar they are
+// already in should take them straight back — not ask for a name again. But the
+// front door still stands, so they can pick a different bar if they meant to.
+describe("a signed-in guest back at the front door", () => {
+  it("walks straight into the bar they are already in", async () => {
+    signIn(); // guest "Ada" at The Spotted Cow (id 1)
+
+    openFrontDoor();
+
+    // The picker is shown, as always — no auto-redirect.
+    const theirBar = await screen.findByRole("button", {
+      name: /The Spotted Cow/,
+    });
+    await userEvent.click(theirBar);
+
+    // Into the menu, without being asked for a name or password again.
+    await screen.findAllByRole("heading", { name: "Negroni", level: 3 });
+    expect(window.location.pathname).toBe("/customer");
+  });
+
+  it("still asks at the door when they pick a different bar", async () => {
+    signIn(); // signed in at The Spotted Cow, not The Anchor
+
+    openFrontDoor();
+
+    const otherBar = await screen.findByRole("button", { name: /The Anchor/ });
+    await userEvent.click(otherBar);
+
+    // Swapping bars goes through the login, as before.
+    await screen.findByText("Login to The Anchor");
+    expect(window.location.pathname).toBe("/");
+  });
+});


### PR DESCRIPTION
Follow-up to #66 (issue #56). Testing the flow surfaced a gap: if you close the tab — or just trim `/customer` off the address — you land back on the front door, and it asks for your name again, even though you never signed out.

## What was actually wrong

Nothing about the session was being lost. The guest cookie lasts weeks, and the app remembers the sign-in in the browser and re-checks it against the server on load — all of which survives a tab close and a URL edit.

The problem was the front door itself: **picking a bar always went to the login**, even the bar you were already signed into. So returning to `/` and tapping your bar re-asked for a name you already held.

## The change

`LandingPage` now remembers which bar (if any) you're already signed into, captured as the page opens — before picking a bar starts overwriting `currentBar`.

- Tapping **that same bar** walks you straight back in (guest → their menu, bartender → their dashboard).
- Tapping **any other bar** still goes through the login, so swapping bars works exactly as before.

Deliberately **not** an auto-redirect off `/`: the landing page always stays (so you can pick a different bar), and the hidden operator gesture on the landing sign is untouched. The fix lives in the pick, not the route.

## Tests

New `frontend/tests/landingRedirect.test.tsx`:
- Tapping your own bar lands you in the menu without re-asking — fails against the old code.
- Tapping a *different* bar still shows the login — guards the swap-bars behaviour.

Frontend suite green: 107 tests, lint, typecheck, build all clean. Frontend-only change; backend untouched.

## Note on the base branch

There's no `staging` branch at the moment, so this targets `main` directly. Happy to retarget if you branch `staging` off `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KoowGibs2wVbYS6bVWjes)_