### PR TITLE
Gate image upload behind auth and accept raster pictures only

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -81,7 +81,13 @@ export function createApp({
   fs.mkdirSync(uploadsDir, { recursive: true });
   app.use(
     "/uploads",
-    express.static(uploadsDir, { maxAge: "7d", fallthrough: false })
+    express.static(uploadsDir, {
+      maxAge: "7d",
+      fallthrough: false,
+      // Serve the file as exactly the type its extension says, so a browser
+      // won't sniff a stored file into something it can run.
+      setHeaders: (res) => res.setHeader("X-Content-Type-Options", "nosniff"),
+    })
   );
 
   app.get(

--- a/backend/src/images.ts
+++ b/backend/src/images.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+
+// The picture types we accept for a drink photo. SVG is left out on purpose:
+// it can carry script, and we serve uploads from our own address, so a stored
+// SVG would run in a guest's browser. Each type maps to the one extension we
+// store it under, so a misleading filename can't choose the extension a file
+// is served with.
+export const ALLOWED_IMAGE_TYPES = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+} as const;
+
+export type AllowedImageType = keyof typeof ALLOWED_IMAGE_TYPES;
+
+/** True for a type we are willing to store. The browser's label, checked. */
+export function isAllowedImageType(mime: string): mime is AllowedImageType {
+  return mime in ALLOWED_IMAGE_TYPES;
+}
+
+/** The extension a given accepted type is stored under. */
+export function extensionFor(mime: AllowedImageType): string {
+  return ALLOWED_IMAGE_TYPES[mime];
+}
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+/**
+ * The real type of a file from its first bytes, or null when it is none of the
+ * pictures we accept. The label a browser sends can say anything, so we look at
+ * the bytes rather than take its word — script wearing an image name is caught
+ * here.
+ */
+export function sniffImageType(header: Buffer): AllowedImageType | null {
+  if (
+    header.length >= 3 &&
+    header[0] === 0xff &&
+    header[1] === 0xd8 &&
+    header[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  if (header.length >= 8 && header.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return "image/png";
+  }
+
+  if (header.length >= 6) {
+    const start = header.subarray(0, 6).toString("latin1");
+    if (start === "GIF87a" || start === "GIF89a") return "image/gif";
+  }
+
+  if (
+    header.length >= 12 &&
+    header.subarray(0, 4).toString("latin1") === "RIFF" &&
+    header.subarray(8, 12).toString("latin1") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+
+  return null;
+}
+
+/** Reads just enough of a file on disk to tell what picture, if any, it is. */
+export function sniffImageFile(filePath: string): AllowedImageType | null {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const header = Buffer.alloc(12);
+    const read = fs.readSync(fd, header, 0, header.length, 0);
+    return sniffImageType(header.subarray(0, read));
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/backend/src/routes/drinks.ts
+++ b/backend/src/routes/drinks.ts
@@ -1,6 +1,9 @@
-import express, { type Response, type Router } from "express";
+import express, {
+  type RequestHandler,
+  type Response,
+  type Router,
+} from "express";
 import multer from "multer";
-import path from "path";
 import fs from "fs";
 
 import type {
@@ -35,6 +38,12 @@ import {
   requireGuest,
 } from "../auth/middleware.js";
 import { deletePhotoIfUnused } from "../uploads.js";
+import {
+  extensionFor,
+  isAllowedImageType,
+  sniffImageFile,
+  type AllowedImageType,
+} from "../images.js";
 
 const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
 
@@ -77,6 +86,17 @@ export default function createDrinkRoutes({
 }: DrinkRoutesOptions): Router {
   const router = express.Router();
 
+  // Only the bartender may upload, and this is checked before multer writes a
+  // thing — so an unsigned request can't drop files on the photos folder.
+  const bartenderOnly: RequestHandler = (_req, res, next) => {
+    try {
+      requireBartender(res);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+
   const upload = multer({
     storage: multer.diskStorage({
       destination(_req, _file, cb) {
@@ -84,13 +104,18 @@ export default function createDrinkRoutes({
         cb(null, uploadsDir);
       },
       filename(_req, file, cb) {
+        // The extension comes from the type we accepted, not the name the
+        // browser sent, so a "photo.svg" can't be served back as an SVG.
         const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-        cb(null, `drink-${unique}${path.extname(file.originalname)}`);
+        const ext = extensionFor(file.mimetype as AllowedImageType);
+        cb(null, `drink-${unique}${ext}`);
       },
     }),
     limits: { fileSize: MAX_PHOTO_BYTES },
     fileFilter(_req, file, cb) {
-      if (file.mimetype.startsWith("image/")) {
+      // Raster pictures only. SVG and everything else is turned away, because
+      // an SVG served from our own address could run script in a guest's page.
+      if (isAllowedImageType(file.mimetype)) {
         cb(null, true);
       } else {
         cb(new Error("Only image files are allowed!"));
@@ -163,10 +188,18 @@ export default function createDrinkRoutes({
 
   router.post(
     "/upload-image",
+    bartenderOnly,
     upload.single("image"),
     route((req, res) => {
-      requireBartender(res);
       if (!req.file) throw HttpError.badRequest("No image file provided");
+
+      // The filter trusted the browser's label; this checks the bytes really
+      // are one of the pictures we accept. A file that isn't is dropped, not
+      // left on disk for the sweep to find a day later.
+      if (!sniffImageFile(req.file.path)) {
+        fs.unlinkSync(req.file.path);
+        throw HttpError.badRequest("Only image files are allowed.");
+      }
 
       res.json({
         success: true,

--- a/backend/tests/images.test.ts
+++ b/backend/tests/images.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  extensionFor,
+  isAllowedImageType,
+  sniffImageType,
+} from "../src/images.js";
+
+describe("what counts as a picture we store", () => {
+  it("accepts the raster types and their extensions", () => {
+    expect(isAllowedImageType("image/png")).toBe(true);
+    expect(extensionFor("image/png")).toBe(".png");
+    expect(extensionFor("image/jpeg")).toBe(".jpg");
+  });
+
+  it("turns away SVG, which can carry script", () => {
+    expect(isAllowedImageType("image/svg+xml")).toBe(false);
+  });
+});
+
+describe("reading a picture's real type from its first bytes", () => {
+  const cases: [string, Buffer][] = [
+    ["image/jpeg", Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00])],
+    [
+      "image/png",
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+    ],
+    ["image/gif", Buffer.from("GIF89a............", "latin1")],
+    ["image/webp", Buffer.from("RIFF\0\0\0\0WEBPVP8 ", "latin1")],
+  ];
+
+  for (const [type, bytes] of cases) {
+    it(`knows ${type}`, () => {
+      expect(sniffImageType(bytes)).toBe(type);
+    });
+  }
+
+  it("sees through an SVG, whatever it is named", () => {
+    const svg = Buffer.from("<svg><script>alert(1)</script></svg>");
+    expect(sniffImageType(svg)).toBeNull();
+  });
+
+  it("returns nothing for a file too short to tell", () => {
+    expect(sniffImageType(Buffer.from([0xff]))).toBeNull();
+  });
+});

--- a/backend/tests/qr-and-uploads.test.ts
+++ b/backend/tests/qr-and-uploads.test.ts
@@ -24,6 +24,17 @@ const PNG = Buffer.from(
   "base64"
 );
 
+// A picture that isn't: an SVG carrying script. Nothing here should let it in.
+const SVG = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+);
+
+/** How many uploaded photos are sitting in the folder right now. */
+const drinkPhotoCount = (uploadsDir: string): number =>
+  fs.existsSync(uploadsDir)
+    ? fs.readdirSync(uploadsDir).filter((name) => name.startsWith("drink-")).length
+    : 0;
+
 afterAll(cleanUpTempDirs);
 
 describe("qr code addresses", () => {
@@ -112,6 +123,7 @@ describe("photo uploads", () => {
   it("turns away anything that is not a photo", async () => {
     const res = await request(app)
       .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
       .attach("image", Buffer.from("just text"), {
         filename: "notes.txt",
         contentType: "text/plain",
@@ -121,11 +133,47 @@ describe("photo uploads", () => {
     expect(res.body.error).toMatch(/image/i);
   });
 
+  it("turns an unsigned upload away before writing anything", async () => {
+    const before = drinkPhotoCount(uploadsDir);
+
+    const res = await request(app)
+      .post("/api/drinks/upload-image")
+      .attach("image", PNG, { filename: "sneaky.png", contentType: "image/png" });
+
+    expect(res.status).toBe(401);
+    // The point of the fix: nothing was saved before the request was refused.
+    expect(drinkPhotoCount(uploadsDir)).toBe(before);
+  });
+
+  it("turns away an SVG even though it calls itself an image", async () => {
+    const res = await request(app)
+      .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
+      .attach("image", SVG, { filename: "x.svg", contentType: "image/svg+xml" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/image/i);
+  });
+
+  it("turns away script wearing a .png name, leaving nothing behind", async () => {
+    const before = drinkPhotoCount(uploadsDir);
+
+    const res = await request(app)
+      .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
+      .attach("image", SVG, { filename: "x.png", contentType: "image/png" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/image/i);
+    expect(drinkPhotoCount(uploadsDir)).toBe(before);
+  });
+
   it("turns away a photo that is too large", async () => {
     const tooBig = Buffer.alloc(6 * 1024 * 1024, 1);
 
     const res = await request(app)
       .post("/api/drinks/upload-image")
+      .set("Cookie", asBartender())
       .attach("image", tooBig, { filename: "huge.png", contentType: "image/png" });
 
     expect(res.status).toBe(400);


### PR DESCRIPTION
Closes #68 and #69 — both live in the upload path, so they're fixed together.

## #68 — auth now runs before multer
The `/upload-image` route checked the session *inside* the handler, after multer had already written the file to disk. An unsigned request wrote a file (kept until the daily sweep) and only then got a 401, so anyone could fill the photos volume. A small `bartenderOnly` guard now runs **before** `upload.single(...)`, so nothing is written until the request is known to be the bartender's.

## #69 — raster-only uploads, no stored SVG
The old filter trusted the client's `content-type` (`startsWith("image/")`) and kept the sent filename's extension, so an `image/svg+xml` slipped through and was later served from our own origin — a stored-XSS path. Now:
- the filter allowlists real raster types only (jpeg/png/webp/gif — **no SVG**);
- the stored extension comes from the accepted type, not the sent filename, so a `photo.svg` can't be served back as SVG;
- after the write, the file's first bytes are checked against the accepted types; a mismatch is deleted and rejected (catches script wearing a `.png` name);
- `/uploads` is served with `X-Content-Type-Options: nosniff`.

## Changes
- `backend/src/images.ts` (new) — allowlist + byte-signature sniffing, unit-tested in `tests/images.test.ts`.
- `backend/src/routes/drinks.ts` — `bartenderOnly` guard before multer; filter/filename/verify wired to the allowlist.
- `backend/src/app.ts` — `nosniff` on the `/uploads` static handler.

## Tests
New regressions (each fails against the old code): unsigned upload is refused with **nothing written**; an SVG is refused; script wearing a `.png` name is refused with nothing left behind. Two existing upload tests were sent without a cookie and relied on the old ordering — they now carry a bartender cookie so they still exercise the filter and the size limit. Full suite: 185 passing, lint + typecheck clean.

## Note
Per CLAUDE.md, a change touching file handling should be run against the built image with a copy of real data before release — I can't do that from here, so flagging it for the staging-image check.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_