### PR TITLE
Store an order's title from the drink, not the client

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -148,7 +148,6 @@ export default function createOrderRoutes(db: Db): Router {
       // can order under someone else's name.
       const { barId, name: customerName } = requireGuest(res);
       const drinkId = requireId(req.body, "drinkId");
-      const drinkTitle = requireText(req.body, "drinkTitle");
 
       const bar = findBar(db, barId);
       const drink = findDrink(db, drinkId, barId);
@@ -185,7 +184,9 @@ export default function createOrderRoutes(db: Db): Router {
         barId,
         customerName,
         drinkId,
-        drinkTitle,
+        // The title is the drink's own, not whatever the client sent, so the
+        // queue and the takings always show the real name.
+        drink.title,
         status
       );
 

--- a/backend/tests/orders.test.ts
+++ b/backend/tests/orders.test.ts
@@ -38,18 +38,19 @@ describe("orders", () => {
 
   // The name on the order now comes from the guest's cookie, not the body, so
   // it's set through the cookie here rather than passed in.
+  // The title on an order is the drink's own, taken on the server, so the body
+  // only carries the drink id (the name comes from the cookie).
   const placeOrder = (
     overrides: {
       customerName?: string;
-      drinkId?: number;
-      drinkTitle?: string | undefined;
+      drinkId?: number | undefined;
     } = {}
   ) => {
     const { customerName = "Mads", ...body } = overrides;
     return request(app)
       .post("/api/orders")
       .set("Cookie", asGuest(customerName))
-      .send({ drinkId, drinkTitle: "Negroni", ...body });
+      .send({ drinkId, ...body });
   };
 
   it("places an order and tells everyone", async () => {
@@ -65,10 +66,20 @@ describe("orders", () => {
   });
 
   it("refuses an order with pieces missing", async () => {
-    const res = await placeOrder({ drinkTitle: undefined });
+    const res = await placeOrder({ drinkId: undefined });
 
     expect(res.status).toBe(400);
     expect(sent).not.toHaveBeenCalled();
+  });
+
+  it("stores the drink's own title, not whatever the client sent", async () => {
+    const res = await request(app)
+      .post("/api/orders")
+      .set("Cookie", asGuest("Mads"))
+      .send({ drinkId, drinkTitle: "Free Top-Shelf Whisky" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.drink_title).toBe("Negroni");
   });
 
   it("refuses an order for a drink that is not there", async () => {

--- a/frontend/src/components/CustomerInterface.tsx
+++ b/frontend/src/components/CustomerInterface.tsx
@@ -98,7 +98,6 @@ const CustomerInterface: React.FC = () => {
           barId: currentBar!.id,
           customerName,
           drinkId: drink.id,
-          drinkTitle: drink.title,
         }),
       });
       setShowOrderPlaced(true);

--- a/frontend/tests/ordering.test.tsx
+++ b/frontend/tests/ordering.test.tsx
@@ -84,12 +84,14 @@ describe("ordering a drink", () => {
     );
 
     const posted = api.calls.find((c) => c.method === "POST");
+    // Only the drink id goes up; the server fills in the title from the drink,
+    // so a guest can't put words on the queue.
     expect(posted?.body).toMatchObject({
       barId: 1,
       customerName: "Ada",
       drinkId: 1,
-      drinkTitle: "Negroni",
     });
+    expect(posted?.body).not.toHaveProperty("drinkTitle");
     expect(await screen.findByText(/order placed/i)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Closes #72.

The order handler already loads the drink (via `findDrink`, which also proves it belongs to the bar), but it stored the `drinkTitle` from the request body instead of the drink's own title. A guest could send any string and have it show in the bartender queue and in the analytics (`GROUP BY drink_title`).

## Changes
- `backend/src/routes/orders.ts` — the insert now uses `drink.title`; `drinkTitle` is no longer read from the body.
- `frontend/src/components/CustomerInterface.tsx` — `placeOrder` sends only `drinkId` (the server fills in the title).

## Tests
- New backend regression: an order sent with `drinkTitle: "Free Top-Shelf Whisky"` still stores `"Negroni"` (the drink's real title). Fails against the old code.
- Backend "pieces missing" test now drops `drinkId` (previously it dropped the now-unused `drinkTitle`).
- Frontend ordering test asserts the POST body carries no `drinkTitle`.
- Both suites green (backend 175, frontend 107), lint + typecheck + build clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_