### PR TITLE
Word the order-limit refusal in terms of the bar's limit

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -172,7 +172,9 @@ export default function createOrderRoutes(db: Db): Router {
 
       // How many a guest may have on the go is the bar's to decide.
       if (waiting >= (bar.max_active_orders || 1)) {
-        throw HttpError.badRequest("Customer already has a pending order");
+        throw HttpError.badRequest(
+          "You already have as many orders on the go as this bar allows"
+        );
       }
 
       // A bar can be set to skip the accept step.

--- a/backend/tests/orders.test.ts
+++ b/backend/tests/orders.test.ts
@@ -78,6 +78,20 @@ describe("orders", () => {
     expect(sent).not.toHaveBeenCalled();
   });
 
+  it("refuses one past the bar's limit, and says so in terms of the limit", async () => {
+    // A bar that allows two at once. The message must not claim there is only
+    // ever one, which is what it used to say however high the limit was set.
+    db.prepare("UPDATE bars SET max_active_orders = 2 WHERE id = ?").run(barId);
+
+    expect((await placeOrder()).status).toBe(201);
+    expect((await placeOrder()).status).toBe(201);
+
+    const third = await placeOrder();
+    expect(third.status).toBe(400);
+    expect(third.body.error).toMatch(/as many|allows/i);
+    expect(third.body.error).not.toMatch(/a pending order/i);
+  });
+
   it("moves an order along and tells everyone", async () => {
     const { body: order } = await placeOrder();
     sent.mockClear();


### PR DESCRIPTION
Closes #73.

The order-limit check reads `bar.max_active_orders`, but the refusal always read *"Customer already has a pending order"* — inaccurate for any bar that raised the limit, where the guest may have several orders in flight. It now reads *"You already have as many orders on the go as this bar allows"*, which is true at any limit.

## Changes
- `backend/src/routes/orders.ts` — the refusal message.

## Tests
New backend regression: a bar with `max_active_orders = 2` accepts two orders, refuses the third, and the message matches the limit-agnostic wording (and explicitly *not* the old "a pending order" text) — so it fails against the old code.

## Note
The message stays English, matching every other guest-facing error the server emits today. Translating those is a separate, pre-existing gap already tracked by #46, so I kept this PR to the correctness fix rather than widening scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_