### PR TITLE
Cap request bodies at 1mb and answer an over-size one cleanly

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -63,8 +63,10 @@ export function createApp({
     app.use(cors({ origin: corsOrigin, credentials: true }));
   }
 
-  app.use(express.json({ limit: "10mb" }));
-  app.use(express.urlencoded({ extended: true, limit: "10mb" }));
+  // Photos come through multer, not here, so a request body is only ever small
+  // fields. 1mb is plenty and caps how much an unsigned caller can make us hold.
+  app.use(express.json({ limit: "1mb" }));
+  app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 
   // Reads the sign-in cookie, if any, before the routes and the live feed run.
   app.use(attachSession);

--- a/backend/src/http.ts
+++ b/backend/src/http.ts
@@ -142,6 +142,12 @@ export function errorReply(
     return;
   }
 
+  // A request body over the size cap, from the JSON/form parser.
+  if (asRecord?.status === 413) {
+    res.status(413).json({ error: "Request body too large." });
+    return;
+  }
+
   console.error("Unhandled error:", err);
   res.status(500).json({
     error: "Internal server error",

--- a/backend/tests/routing.test.ts
+++ b/backend/tests/routing.test.ts
@@ -35,6 +35,21 @@ describe("api routing", () => {
     expect(res.type).toBe("application/json");
   });
 
+  it("turns away a request body past the size cap, cleanly", async () => {
+    // Comfortably over the 1mb cap. The reply should say so, not fall through
+    // to a 500.
+    const huge = { note: "x".repeat(1_100_000) };
+
+    const res = await request(app)
+      .post("/api/auth/bartender")
+      .set("Content-Type", "application/json")
+      .send(JSON.stringify(huge));
+
+    expect(res.status).toBe(413);
+    expect(res.type).toBe("application/json");
+    expect(res.body.error).toMatch(/too large/i);
+  });
+
   it("reports health", async () => {
     const res = await request(app).get("/api/health");
 


### PR DESCRIPTION
Closes #75.

Photos are uploaded through multer (capped at 5 MB separately), so a JSON/form body only ever carries small fields. The `express.json`/`urlencoded` limit was 10 MB — just headroom an unsigned caller could make the server buffer. Lowered to 1 MB.

While here: an over-size body previously fell through `errorReply` to a generic 500. The handler now translates the body-parser's `413` into a plain `{ error: "Request body too large." }`, so the cap is observable.

## Changes
- `backend/src/app.ts` — 10mb → 1mb for JSON and urlencoded.
- `backend/src/http.ts` — `errorReply` handles status `413`.

## Tests
New routing test: a ~1.1 MB JSON body is refused with **413** and the clean message (previously this path produced a 500). Full suite green, lint + typecheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_