### PR TITLE
Drop the redundant `| null` from decodeToken's return type

### DIFF
--- a/backend/src/auth/tokens.ts
+++ b/backend/src/auth/tokens.ts
@@ -74,7 +74,7 @@ export function encodeToken(payload: unknown): string {
  * the body isn't JSON. The caller checks the shape — this only proves we signed
  * it and it parses.
  */
-export function decodeToken(token: string): unknown | null {
+export function decodeToken(token: string): unknown {
   const dot = token.indexOf(".");
   if (dot <= 0) return null;
 


### PR DESCRIPTION
Closes #76.

`decodeToken` was typed `unknown | null`, which collapses to `unknown` — the `| null` documented an intent the type couldn't carry. Runtime behaviour is unchanged (it still returns `null` on a bad signature or non-JSON body); only the annotation is tidied.

## Changes
- `backend/src/auth/tokens.ts` — return type `unknown`.

Type-only change, no behaviour difference, so no new test. Typecheck + lint + full suite green.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_