### PR TITLE
Throttle repeated wrong passwords on the sign-in routes

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "home-bar-backend",
+  "name": "barkeep-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "home-bar-backend",
+      "name": "barkeep-backend",
       "version": "1.0.0",
       "dependencies": {
         "bcrypt": "6.0.0",
@@ -13,6 +13,7 @@
         "cors": "2.8.5",
         "dotenv": "17.2.0",
         "express": "4.21.2",
+        "express-rate-limit": "^8.6.2",
         "multer": "2.0.1",
         "qrcode": "^1.5.4"
       },
@@ -869,9 +870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,9 +887,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,9 +904,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -929,9 +921,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -949,9 +938,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +955,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2972,6 +2955,48 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3394,6 +3419,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3653,9 +3687,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3677,9 +3708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3701,9 +3729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3725,9 +3750,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "cors": "2.8.5",
     "dotenv": "17.2.0",
     "express": "4.21.2",
+    "express-rate-limit": "^8.6.2",
     "multer": "2.0.1",
     "qrcode": "^1.5.4"
   },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import {
 } from "./config.js";
 import { errorReply, route } from "./http.js";
 import { attachSession } from "./auth/middleware.js";
+import { adminLoginLimiter, guestLoginLimiter } from "./rateLimit.js";
 import { createRealtime } from "./realtime.js";
 import type { Db } from "./db/queries.js";
 
@@ -33,6 +34,8 @@ export interface AppOptions {
   publicUrl?: string;
   trustProxy?: TrustProxy;
   requestLogging?: boolean;
+  /** Throttle repeated wrong passwords on the sign-in routes. Off in tests. */
+  rateLimit?: boolean;
   /** The operator panel's password. Unset switches the panel off. */
   operatorPassword?: string | undefined;
 }
@@ -49,6 +52,7 @@ export function createApp({
   publicUrl = PUBLIC_URL,
   trustProxy = TRUST_PROXY,
   requestLogging = NODE_ENV !== "test",
+  rateLimit = NODE_ENV !== "test",
   operatorPassword = OPERATOR_PASSWORD,
 }: AppOptions): Express {
   if (!db) throw new Error("createApp needs a database");
@@ -112,6 +116,16 @@ export function createApp({
   const realtime = createRealtime();
   app.locals["realtime"] = realtime;
   app.get("/api/events", (req, res) => realtime.subscribe(req, res));
+
+  // Throttle wrong passwords on the sign-in routes, before the routes run.
+  if (rateLimit) {
+    const admin = adminLoginLimiter();
+    const guest = guestLoginLimiter();
+    app.use("/api/auth/bartender", admin);
+    app.use("/api/operator/login", admin);
+    app.use("/api/auth/guest", guest);
+    app.use("/api/bars/:id/guest-token-login", guest);
+  }
 
   app.use("/api/bars", createBarRoutes({ db, publicUrl }));
   app.use("/api/drinks", createDrinkRoutes({ db, uploadsDir }));

--- a/backend/src/rateLimit.ts
+++ b/backend/src/rateLimit.ts
@@ -1,0 +1,35 @@
+import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
+
+// Slows down password guessing on the sign-in routes. Only *failed* attempts
+// count (`skipSuccessfulRequests`), so a whole party signing in for real over
+// one shared connection is never turned away — only the guessing is.
+
+const WINDOW_MS = 15 * 60 * 1000;
+
+// Hosts are few people, so a tighter cap on wrong passwords is fine.
+export const ADMIN_ATTEMPT_LIMIT = 10;
+// A party of guests may all share one home connection, so theirs is looser.
+export const GUEST_ATTEMPT_LIMIT = 30;
+
+function limiter(max: number): RateLimitRequestHandler {
+  return rateLimit({
+    windowMs: WINDOW_MS,
+    limit: max,
+    skipSuccessfulRequests: true,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req, res) => {
+      res.status(429).json({
+        error: "Too many attempts. Please wait a few minutes and try again.",
+      });
+    },
+  });
+}
+
+/** For the bartender and operator sign-ins. */
+export const adminLoginLimiter = (): RateLimitRequestHandler =>
+  limiter(ADMIN_ATTEMPT_LIMIT);
+
+/** For the guest sign-ins, which a crowd may all come through at once. */
+export const guestLoginLimiter = (): RateLimitRequestHandler =>
+  limiter(GUEST_ATTEMPT_LIMIT);

--- a/backend/tests/rate-limit.test.ts
+++ b/backend/tests/rate-limit.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+
+import { createApp } from "../src/app.js";
+import {
+  makeTestDatabase,
+  makeTempDir,
+  cleanUpTempDirs,
+} from "./helpers.js";
+import { ADMIN_ATTEMPT_LIMIT } from "../src/rateLimit.js";
+
+afterAll(cleanUpTempDirs);
+
+const OPERATOR_PASSWORD = "operator-secret";
+
+/** An app with throttling switched on (it is off by default under test). */
+function makeApp() {
+  return createApp({
+    db: makeTestDatabase(),
+    uploadsDir: makeTempDir(),
+    frontendDir: makeTempDir(),
+    rateLimit: true,
+    operatorPassword: OPERATOR_PASSWORD,
+  });
+}
+
+describe("throttling wrong passwords", () => {
+  it("turns a run of wrong passwords away once the limit is passed", async () => {
+    const app = makeApp();
+
+    // The limiter lets this many wrong tries through before it steps in.
+    for (let i = 0; i < ADMIN_ATTEMPT_LIMIT; i++) {
+      const res = await request(app)
+        .post("/api/operator/login")
+        .send({ password: "wrong" });
+      expect(res.status).toBe(401);
+    }
+
+    const blocked = await request(app)
+      .post("/api/operator/login")
+      .send({ password: "wrong" });
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.error).toMatch(/too many/i);
+  });
+
+  it("does not count the ones that get in, so a real crowd is never locked out", async () => {
+    const app = makeApp();
+
+    // Well past the limit, but every one succeeds, so none of them count.
+    for (let i = 0; i < ADMIN_ATTEMPT_LIMIT + 5; i++) {
+      const res = await request(app)
+        .post("/api/operator/login")
+        .send({ password: OPERATOR_PASSWORD });
+      expect(res.status).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
Closes #70.

Adds `express-rate-limit` to the sign-in routes so a password can't be guessed at indefinitely: `/api/auth/bartender`, `/api/auth/guest`, `/api/bars/:id/guest-token-login`, and `/api/operator/login`.

## The party problem, and how this avoids it
A naive per-IP cap would lock out a whole party, since guests often share one home connection. So **only failed attempts count** (`skipSuccessfulRequests`) — a crowd all signing in for real never trips it; only the guessing does. Hosts (few people) get a tighter cap than guests:

- admin (bartender + operator): **10** failed attempts / 15 min per IP;
- guest (sign-in + QR token): **30** failed attempts / 15 min per IP.

Blocked requests get a `429` with `{ error: "Too many attempts. …" }`. Keying uses `req.ip`, which already honours the app's conservative `trust proxy` default.

## Test-friendliness
The limiter is **off under `NODE_ENV=test`** by default (new `rateLimit` option on `createApp`), so the existing suites stay deterministic, and it's exercised by a dedicated test that switches it on.

## Changes
- `backend/package.json` — add `express-rate-limit`.
- `backend/src/rateLimit.ts` (new) — the two limiters; only failures count.
- `backend/src/app.ts` — apply them before the routers, behind the `rateLimit` flag.
- `backend/tests/rate-limit.test.ts` — a run of wrong passwords is blocked after the cap; a run of **successful** logins past the cap is never blocked (the party case).

## Note
The caps are sensible defaults, not tuned to a specific venue — easy to adjust in `rateLimit.ts` if a real party turns out to need more headroom.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_