### PR TITLE
Show how to run the container as an ordinary user

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ Two folders need to survive an upgrade:
 Back both up together. The database refers to photos by filename, so they only
 make sense as a pair.
 
+### Running as an ordinary user
+
+By default the container runs as root, which is the simplest thing and matches
+how most setups already have their `data/` and `uploads/` folders. If you would
+rather it ran as an ordinary user, set `PUID` and `PGID` to the user you want.
+The two folders' ownership is put right on start, so an existing setup keeps
+working after the switch.
+
+```yaml
+services:
+  barkeep:
+    environment:
+      PUID: 1000
+      PGID: 1000
+```
+
+`1000:1000` is the first ordinary user on most machines; `id -u` and `id -g`
+tell you yours. This is optional — leave both unset and nothing changes.
+
 ### Setting up your bar
 
 Open the address in a browser and create a bar. You pick two passwords: one for


### PR DESCRIPTION
Closes #74.

Non-root already works: setting `PUID`/`PGID` makes the entrypoint fix the `data/` and `uploads/` folders' ownership and drop privileges via `setpriv`. The gap was discoverability — it was only a row in the settings table. This adds a short worked example under **Running it**, and keeps **root the default** so existing installs (whose data was created as root) are untouched.

## Changes
- `README.md` — a "Running as an ordinary user" subsection with a compose snippet, explicitly optional.

No code change, so nothing to test in the suite. The `PUID`/`PGID` path itself is existing behaviour; worth a confirming run on the staging image as part of the usual pre-release container check (I couldn't exercise the container from here — no Docker daemon in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZJMiHjwHcnnxCJwzAmNUw)_